### PR TITLE
Refactor auth request preprocessing

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -2595,8 +2595,8 @@ func (a *Authentication) getFromLocalCache(ctx *gin.Context) bool {
 // If not found in the cache, it checks if the request is a brute force attack and updates the brute force counter.
 // It then performs a post Lua action and triggers a failed authentication response.
 // If a brute force attack is detected, it returns true, otherwise false.
-func (a *Authentication) preproccessAuthRequest(ctx *gin.Context) (reject bool) {
-	if found := a.getFromLocalCache(ctx); !found {
+func (a *Authentication) preproccessAuthRequest(ctx *gin.Context) (found bool, reject bool) {
+	if found = a.getFromLocalCache(ctx); !found {
 		stats.CacheMisses.Inc()
 
 		if a.checkBruteForce() {
@@ -2604,11 +2604,11 @@ func (a *Authentication) preproccessAuthRequest(ctx *gin.Context) (reject bool) 
 			a.postLuaAction(&PassDBResult{})
 			a.authFail(ctx)
 
-			return true
+			return false, true
 		}
 	} else {
 		stats.CacheHits.Inc()
 	}
 
-	return false
+	return found, false
 }

--- a/server/core/http.go
+++ b/server/core/http.go
@@ -61,8 +61,10 @@ func httpQueryHandler(ctx *gin.Context) {
 				return
 			}
 
-			if auth.preproccessAuthRequest(ctx) {
+			if found, reject := auth.preproccessAuthRequest(ctx); reject {
 				return
+			} else if found {
+				auth.withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 			}
 
 			switch ctx.Param("service") {
@@ -82,8 +84,10 @@ func httpQueryHandler(ctx *gin.Context) {
 				return
 			}
 
-			if auth.preproccessAuthRequest(ctx) {
+			if found, reject := auth.preproccessAuthRequest(ctx); reject {
 				return
+			} else if found {
+				auth.withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 			}
 
 			switch ctx.Param("service") {

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -1139,10 +1139,12 @@ func initializeAuthLogin(ctx *gin.Context) (*Authentication, error) {
 		return nil, err
 	}
 
-	auth = auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
+	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 
-	if auth.preproccessAuthRequest(ctx) {
+	if found, reject := auth.preproccessAuthRequest(ctx); reject {
 		return nil, errors2.ErrBruteForceAttack
+	} else if found {
+		auth.withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 	}
 
 	return auth, nil

--- a/server/core/register.go
+++ b/server/core/register.go
@@ -194,10 +194,12 @@ func loginPOST2FAHandler(ctx *gin.Context) {
 
 	auth.UsernameOrig = auth.Username
 
-	if auth.preproccessAuthRequest(ctx) {
+	if found, reject := auth.preproccessAuthRequest(ctx); reject {
 		handleErr(ctx, errors2.ErrBruteForceAttack)
 
 		return
+	} else if found {
+		auth.withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 	}
 
 	authResult = auth.handlePassword(ctx)


### PR DESCRIPTION
The way auth requests are preprocessed has been updated in the `http.go`, `auth.go`, `hydra.go`, and `register.go` files. Now, the `preproccessAuthRequest` function not only checks if a request exists in local cache, but also if it should be rejected. This update streamlines the authentication process and provides more detailed response handling, leading to more efficient and clear operations.