### PR TITLE
Implement Lua action checks for early exit

### DIFF
--- a/server/config/file.go
+++ b/server/config/file.go
@@ -465,6 +465,46 @@ func (f *File) GetLuaSearchProtocol(protocol string) (*LuaSearchProtocol, error)
 	return f.GetLuaSearchProtocol(global.ProtoDefault)
 }
 
+// HaveLuaFilters is a method on the File struct.
+// It checks if the File struct has Lua filters.
+// It returns true if there are Lua filters, and false otherwise.
+func (f *File) HaveLuaFilters() bool {
+	if f.HaveLua() {
+		return len(f.Lua.Filters) > 0
+	}
+
+	return false
+}
+
+// HaveLuaFeatures is a method on the File struct.
+// It checks if the File struct has Lua features.
+// It returns true if there are Lua features, and false otherwise.
+func (f *File) HaveLuaFeatures() bool {
+	if f.HaveLua() {
+		return len(f.Lua.Features) > 0
+	}
+
+	return false
+}
+
+// HaveLuaActions is a method on the File struct.
+// It checks if the File struct has Lua actions.
+// It returns true if the File struct has Lua actions, otherwise returns false.
+func (f *File) HaveLuaActions() bool {
+	if f.HaveLua() {
+		return len(f.Lua.Actions) > 0
+	}
+
+	return false
+}
+
+// HaveLua is a method on the File struct.
+// It checks if the Lua field in the File struct is not nil.
+// It returns a boolean value indicating whether Lua is present or not.
+func (f *File) HaveLua() bool {
+	return f.Lua != nil
+}
+
 /*
  * Generic EnvConfig mapping
  */
@@ -817,6 +857,7 @@ func (f *File) validatePassDBBackends() error {
 			}
 		case global.BackendUnknown:
 		case global.BackendCache:
+		case global.BackendLocalCache:
 		}
 	}
 

--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -767,29 +767,31 @@ func (a *Authentication) checkBruteForce() (blockClientIP bool) {
 			"rule", rules[index].Name,
 		)
 
-		finished := make(chan action.Done)
+		if config.LoadableConfig.HaveLuaActions() {
+			finished := make(chan action.Done)
 
-		action.RequestChan <- &action.Action{
-			LuaAction:         global.LuaActionBruteForce,
-			Debug:             config.EnvConfig.Verbosity.Level() == global.LogLevelDebug,
-			Repeating:         alreadyTriggered,
-			BruteForceCounter: a.BruteForceCounter[rules[index].Name],
-			Session:           *a.GUID,
-			ClientIP:          a.ClientIP,
-			ClientPort:        a.XClientPort,
-			ClientNet:         network.String(),
-			ClientID:          a.XClientID,
-			LocalIP:           a.XLocalIP,
-			LocalPort:         a.XPort,
-			Username:          a.Username,
-			Password:          a.Password,
-			Protocol:          a.Protocol.Get(),
-			BruteForceName:    rules[index].Name,
-			Context:           a.Context,
-			FinishedChan:      finished,
+			action.RequestChan <- &action.Action{
+				LuaAction:         global.LuaActionBruteForce,
+				Debug:             config.EnvConfig.Verbosity.Level() == global.LogLevelDebug,
+				Repeating:         alreadyTriggered,
+				BruteForceCounter: a.BruteForceCounter[rules[index].Name],
+				Session:           *a.GUID,
+				ClientIP:          a.ClientIP,
+				ClientPort:        a.XClientPort,
+				ClientNet:         network.String(),
+				ClientID:          a.XClientID,
+				LocalIP:           a.XLocalIP,
+				LocalPort:         a.XPort,
+				Username:          a.Username,
+				Password:          a.Password,
+				Protocol:          a.Protocol.Get(),
+				BruteForceName:    rules[index].Name,
+				Context:           a.Context,
+				FinishedChan:      finished,
+			}
+
+			<-finished
 		}
-
-		<-finished
 
 		return true
 	}

--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -162,7 +162,7 @@ func NewWorker() *Worker {
 func (aw *Worker) Work(ctx context.Context) {
 	aw.ctx = &ctx
 
-	if config.LoadableConfig.Lua == nil {
+	if !config.LoadableConfig.HaveLuaActions() {
 		return
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -197,8 +197,10 @@ func PreCompileFeatures() error {
 		return nil
 	}
 
-	if err := feature.PreCompileLuaFeatures(); err != nil {
-		return err
+	if config.LoadableConfig.HaveLuaFeatures() {
+		if err := feature.PreCompileLuaFeatures(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -213,12 +215,10 @@ func PreCompileFilters() error {
 		return nil
 	}
 
-	if len(config.LoadableConfig.Lua.Filters) == 0 {
-		return nil
-	}
-
-	if err := filter.PreCompileLuaFilters(); err != nil {
-		return err
+	if config.LoadableConfig.HaveLuaFilters() {
+		if err := filter.PreCompileLuaFilters(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Implemented checks for the presence of Lua actions, filters or features in various parts of the application to enable early exit when there are none available. This introduces a consistent and efficient way to check whether any Lua related functionalities are available before attempting to process them. This change not only enhances the code readability but also improves the application performance by avoiding unnecessary computations when there are no Lua actions, filters or features.