### PR TITLE
Add LDAP reply cleanup function in backend

### DIFF
--- a/server/backend/lua.go
+++ b/server/backend/lua.go
@@ -175,6 +175,7 @@ func setupGlobals(luaRequest *LuaRequest, L *lua.LState, logs *lualib.CustomLogK
 	if config.LoadableConfig.HaveLDAPBackend() {
 		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(GlobalLDAPBridge.SendRequest(luaRequest.HTTPClientContext)))
 		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(GlobalLDAPBridge.GetReply))
+		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(GlobalLDAPBridge.CleanupReply))
 	}
 
 	L.SetGlobal(global.LuaDefaultTable, globals)

--- a/server/global/const.go
+++ b/server/global/const.go
@@ -974,6 +974,9 @@ const (
 
 	// LuaFnGetLDAPReply represents the constant for the name of the function to get an LDAP reply.
 	LuaFnGetLDAPReply = "get_ldap_reply"
+
+	// LuaFnCleanupLDAPReply represents the function name used to perform cleanup on LDAP reply data.
+	LuaFnCleanupLDAPReply = "cleanup_ldap_reply"
 )
 
 const (

--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -262,6 +262,7 @@ func (aw *Worker) setupGlobals(L *lua.LState, logs *lualib.CustomLogKeyValue, ht
 	if config.LoadableConfig.HaveLDAPBackend() {
 		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(backend.GlobalLDAPBridge.SendRequest(context.Background())))
 		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.GetReply))
+		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.CleanupReply))
 	}
 
 	L.SetGlobal(global.LuaDefaultTable, globals)

--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -228,6 +228,7 @@ func (r *Request) setGlobals(ctx *gin.Context, L *lua.LState) *lua.LTable {
 	if config.LoadableConfig.HaveLDAPBackend() {
 		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(backend.GlobalLDAPBridge.SendRequest(ctx)))
 		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.GetReply))
+		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.CleanupReply))
 	}
 
 	return globals

--- a/server/lualib/filter/filter.go
+++ b/server/lualib/filter/filter.go
@@ -356,6 +356,7 @@ func setGlobals(ctx *gin.Context, r *Request, L *lua.LState, backendResult **lua
 	if config.LoadableConfig.HaveLDAPBackend() {
 		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(backend.GlobalLDAPBridge.SendRequest(ctx)))
 		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.GetReply))
+		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.CleanupReply))
 	}
 
 	L.SetGlobal(global.LuaDefaultTable, globals)


### PR DESCRIPTION
A new function 'CleanupReply' has been added to the LDAPBridge. This function is responsible for cleaning up the reply channel associated with a given request ID. It has been set in lua global functions using the constant 'LuaFnCleanupLDAPReply' if LDAP backend is available.