### PR TITLE
Refactor LDAP request and reply system

### DIFF
--- a/server/backend/lua.go
+++ b/server/backend/lua.go
@@ -173,9 +173,7 @@ func setupGlobals(luaRequest *LuaRequest, L *lua.LState, logs *lualib.CustomLogK
 	globals.RawSetString(global.LuaFnRedisExpire, L.NewFunction(lualib.RedisExpire))
 
 	if config.LoadableConfig.HaveLDAPBackend() {
-		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(GlobalLDAPBridge.SendRequest(luaRequest.HTTPClientContext)))
-		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(GlobalLDAPBridge.GetReply))
-		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(GlobalLDAPBridge.CleanupReply))
+		globals.RawSetString(global.LuaFnLDAPSearch, L.NewFunction(LuaLDAPSearch(luaRequest.HTTPClientContext)))
 	}
 
 	L.SetGlobal(global.LuaDefaultTable, globals)

--- a/server/global/const.go
+++ b/server/global/const.go
@@ -969,14 +969,8 @@ const (
 	// LuaFnCheckBackendConnection represents the Lua function name for checking the backend connection.
 	LuaFnCheckBackendConnection = "check_backend_connection"
 
-	// LuaFnSendLDAPRequest represents the name of the Lua function used to send an LDAP request.
-	LuaFnSendLDAPRequest = "send_ldap_request"
-
-	// LuaFnGetLDAPReply represents the constant for the name of the function to get an LDAP reply.
-	LuaFnGetLDAPReply = "get_ldap_reply"
-
-	// LuaFnCleanupLDAPReply represents the function name used to perform cleanup on LDAP reply data.
-	LuaFnCleanupLDAPReply = "cleanup_ldap_reply"
+	// LuaFnLDAPSearch represents the name of the Lua function used to do an LDAP search request.
+	LuaFnLDAPSearch = "ldap_search"
 )
 
 const (

--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -260,9 +260,7 @@ func (aw *Worker) setupGlobals(L *lua.LState, logs *lualib.CustomLogKeyValue, ht
 	globals.RawSetString(global.LuaFnRedisExpire, L.NewFunction(lualib.RedisExpire))
 
 	if config.LoadableConfig.HaveLDAPBackend() {
-		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(backend.GlobalLDAPBridge.SendRequest(context.Background())))
-		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.GetReply))
-		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.CleanupReply))
+		globals.RawSetString(global.LuaFnLDAPSearch, L.NewFunction(backend.LuaLDAPSearch(context.Background())))
 	}
 
 	L.SetGlobal(global.LuaDefaultTable, globals)

--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -226,9 +226,7 @@ func (r *Request) setGlobals(ctx *gin.Context, L *lua.LState) *lua.LTable {
 	globals.RawSetString(global.LuaFnRedisExpire, L.NewFunction(lualib.RedisExpire))
 
 	if config.LoadableConfig.HaveLDAPBackend() {
-		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(backend.GlobalLDAPBridge.SendRequest(ctx)))
-		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.GetReply))
-		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.CleanupReply))
+		globals.RawSetString(global.LuaFnLDAPSearch, L.NewFunction(backend.LuaLDAPSearch(ctx)))
 	}
 
 	return globals

--- a/server/lualib/filter/filter.go
+++ b/server/lualib/filter/filter.go
@@ -354,9 +354,7 @@ func setGlobals(ctx *gin.Context, r *Request, L *lua.LState, backendResult **lua
 	}
 
 	if config.LoadableConfig.HaveLDAPBackend() {
-		globals.RawSetString(global.LuaFnSendLDAPRequest, L.NewFunction(backend.GlobalLDAPBridge.SendRequest(ctx)))
-		globals.RawSetString(global.LuaFnGetLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.GetReply))
-		globals.RawSetString(global.LuaFnCleanupLDAPReply, L.NewFunction(backend.GlobalLDAPBridge.CleanupReply))
+		globals.RawSetString(global.LuaFnLDAPSearch, L.NewFunction(backend.LuaLDAPSearch(ctx)))
 	}
 
 	L.SetGlobal(global.LuaDefaultTable, globals)


### PR DESCRIPTION
This commit streamlines the handling of LDAP requests and replies. The previous system of using 'send', 'get' and 'cleanup' functions for LDAP requests has been replaced with a single 'ldap_search' function. This change simplifies the code base, improves maintainability and minimizes thread safety concerns by eliminating the need for separate request and reply functions along with the associated channel management.