### PR TITLE
Add build badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Development Build](https://github.com/croessner/nauthilus/actions/workflows/build-features.yaml/badge.svg?branch=features)](https://github.com/croessner/nauthilus/actions/workflows/build-features.yaml)
+[![Development Docker Build](https://github.com/croessner/nauthilus/actions/workflows/docker-features.yaml/badge.svg?branch=features)](https://github.com/croessner/nauthilus/actions/workflows/docker-features.yaml)
+[![Release Build](https://github.com/croessner/nauthilus/actions/workflows/build-stable.yaml/badge.svg)](https://github.com/croessner/nauthilus/actions/workflows/build-stable.yaml)
+[![Production Docker Build](https://github.com/croessner/nauthilus/actions/workflows/docker-stable.yaml/badge.svg)](https://github.com/croessner/nauthilus/actions/workflows/docker-stable.yaml)
 # Nauthilus
 
 Nauthilus is a general purpose authentication service written in Go. It is designed to work as a central place where all kinds of 


### PR DESCRIPTION
Two build status badges and two Docker build status badges were added to the README.md file. These provide a quick visual indication of the build status for both the development and production versions of the project.