### PR TITLE
Add build tag-based conditional rendering and endpoint access

### DIFF
--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -16,6 +16,7 @@ import (
 	errors2 "github.com/croessner/nauthilus/server/errors"
 	"github.com/croessner/nauthilus/server/global"
 	"github.com/croessner/nauthilus/server/logging"
+	"github.com/croessner/nauthilus/server/tags"
 	"github.com/croessner/nauthilus/server/util"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
@@ -53,6 +54,9 @@ type Language struct {
 }
 
 type LoginPageData struct {
+	// InDevelopment is a flag that is true, if the build-tag dev is used.
+	InDevelopment bool
+
 	// Determines if the Welcome message should be displayed
 	WantWelcome bool
 
@@ -1051,6 +1055,7 @@ func (a *ApiConfig) handleLoginNoSkip() {
 		LanguagePassive:     languagePassive,
 		CSRFToken:           a.csrfToken,
 		LoginChallenge:      a.challenge,
+		InDevelopment:       tags.IsDevelopment,
 	}
 
 	a.ctx.HTML(http.StatusOK, "login.html", loginData)

--- a/server/tags/dev.go
+++ b/server/tags/dev.go
@@ -1,0 +1,5 @@
+//go:build dev
+
+package tags
+
+const IsDevelopment = true

--- a/server/tags/disableregistration.go
+++ b/server/tags/disableregistration.go
@@ -1,0 +1,5 @@
+//go:build !register2fa
+
+package tags
+
+const Register2FA = false

--- a/server/tags/enableregistration.go
+++ b/server/tags/enableregistration.go
@@ -1,0 +1,5 @@
+//go:build register2fa
+
+package tags
+
+const Register2FA = true

--- a/server/tags/prod.go
+++ b/server/tags/prod.go
@@ -1,0 +1,5 @@
+//go:build !dev
+
+package tags
+
+const IsDevelopment = false

--- a/static/login.html
+++ b/static/login.html
@@ -49,11 +49,15 @@
                     <button type="submit" id="submit" name="submit" value="{{ .Submit }}" data-loginurl="{{ .PostLoginEndpoint }}/post">
                         {{ .Submit }}
                     </button>
+                    {{ if .InDevelopment }}
                     <p class="text center vs-5">{{ .Or }}</p>
                     <div class="vs-15"></div>
                     <button class="device" type="submit" id="device" name="device" value="{{ .Device }}" data-deviceurl="{{ .DeviceLoginEndpoint }}">
                         {{ .Device }}
                     </button>
+                    {{ else }}
+                    <div id="device" style="display: none;"></div>
+                    {{ end }}
                     <div class="vs-5"></div>
                     <input type="checkbox" id="remember" name="remember" value="on"/>
                     <label for="remember">{{ .Remember }}</label>


### PR DESCRIPTION
In this update, build tags have been added to enable or disable certain endpoint accesses and UI rendering based on the build environment. Specifically, the "dev" build tag determines whether the device login button is displayed on the login page, and the "register2fa" build tag configures whether the 2FA endpoints are accessible. Making these features conditional improves the flexibility of customization based on the application's deployment environment.