### PR TITLE
Update username validation logic

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -2080,10 +2080,12 @@ func setupAuth(ctx *gin.Context, auth *Authentication) {
 		setupHTTPBasiAuth(ctx, auth)
 	}
 
-	if !util.ValidateUsername(auth.Username) {
-		auth.Username = ""
+	if ctx.Query("mode") != "list-accounts" {
+		if !util.ValidateUsername(auth.Username) {
+			auth.Username = ""
 
-		ctx.Error(errors2.ErrInvalidUsername)
+			ctx.Error(errors2.ErrInvalidUsername)
+		}
 	}
 
 	auth.withDefaults(ctx)


### PR DESCRIPTION
This commit changes the validation logic for the username in auth.go. The username validation is now only performed if the query mode isn't 'list-accounts', enhancing the flexibility of the validation process.