### PR TITLE
Refactor auth request processing and TOTP secret retrieval

### DIFF
--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -1157,10 +1157,8 @@ func initializeAuthLogin(ctx *gin.Context) (*Authentication, error) {
 
 	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 
-	if found, reject := auth.preproccessAuthRequest(ctx); reject {
+	if _, reject := auth.preproccessAuthRequest(ctx); reject {
 		return nil, errors2.ErrBruteForceAttack
-	} else if found {
-		auth.withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 	}
 
 	return auth, nil

--- a/server/core/ldap.go
+++ b/server/core/ldap.go
@@ -67,7 +67,7 @@ func saveMasterUserTOTPSecret(masterUserMode bool, ldapReply *backend.LDAPReply,
 	if masterUserMode {
 		// Check if the master user does have a TOTP secret.
 		if value, okay := ldapReply.Result[totpSecretField]; okay {
-			totpSecretPre = value
+			return value
 		}
 	}
 


### PR DESCRIPTION
In this commit, we made changes in the authentication mechanism and the TOTP secret retrieval process. Firstly, we simplified our condition in the authentication process where the 'found' variable was removed to reduce unnecessary code complexity. Secondly, we updated the TOTP secret retrieval in LDAP to immediately return the value, improving the readability and efficiency of our code.