### PR TITLE
Refactor code for secrets and session management

### DIFF
--- a/server/config/server.go
+++ b/server/config/server.go
@@ -19,6 +19,7 @@ type ServerSection struct {
 	Insights            Insights    `mapstructure:"insights"`
 	Redis               Redis       `mapstructure:"redis"`
 	MasterUser          MasterUser  `mapstructure:"master_user"`
+	Frontend            Frontend    `mapstructure:"frontend"`
 }
 
 type TLS struct {
@@ -54,6 +55,7 @@ type DNS struct {
 type Redis struct {
 	DatabaseNmuber int       `mapstructure:"database_number"`
 	Prefix         string    `mapstructure:"prefix"`
+	PasswordNonce  string    `mapstructure:"password_nonce"`
 	PoolSize       int       `mapstructure:"pool_size"`
 	IdlePoolSize   int       `mapstructure:"idle_pool_size"`
 	TLS            TLS       `mapstructure:"tls"`
@@ -91,4 +93,11 @@ type Cluster struct {
 type MasterUser struct {
 	Enabled   bool   `mapstructure:"enabled"`
 	Delimiter string `mapstructure:"delimiter"`
+}
+
+type Frontend struct {
+	Enabled            bool   `mapstructure:"enabled"`
+	CSRFSecret         string `mapstructure:"csrf_secret"`
+	CookieStoreAuthKey string `mapstructure:"cookie_store_auth_key"`
+	CookieStoreEncKey  string `mapstructure:"cookie_store_encryption_key"`
 }

--- a/server/core/http.go
+++ b/server/core/http.go
@@ -429,7 +429,7 @@ func setupWebAuthn() (*webauthn.WebAuthn, error) {
 // The function also sets the session options including the path, secure flag, and SameSite mode.
 // The configured session store is then returned.
 func setupSessionStore() sessions.Store {
-	sessionStore := cookie.NewStore([]byte(config.LoadableConfig.CookieStoreAuthKey), []byte(config.LoadableConfig.CookieStoreEncKey))
+	sessionStore := cookie.NewStore([]byte(config.LoadableConfig.Server.Frontend.CookieStoreAuthKey), []byte(config.LoadableConfig.Server.Frontend.CookieStoreEncKey))
 	sessionStore.Options(sessions.Options{
 		Path:     "/",
 		Secure:   true,
@@ -744,13 +744,16 @@ func HTTPApp(ctx context.Context) {
 	// Parse static folder for template files
 	router.LoadHTMLGlob(viper.GetString("html_static_content_path") + "/*.html")
 
-	store := setupSessionStore()
+	if config.LoadableConfig.Server.Frontend.Enabled {
+		store := setupSessionStore()
 
-	setupHydraEndpoints(router, store)
-	setup2FAEndpoints(router, store)
-	setupWebAuthnEndpoints(router, store)
+		setupHydraEndpoints(router, store)
+		setup2FAEndpoints(router, store)
+		setupWebAuthnEndpoints(router, store)
+		setupNotifyEndpoint(router, store)
+	}
+
 	setupStaticContent(router)
-	setupNotifyEndpoint(router, store)
 	setupBackChannelEndpoints(router)
 
 	// www.SetKeepAlivesEnabled(false)

--- a/server/util/util.go
+++ b/server/util/util.go
@@ -153,7 +153,7 @@ func (c *CryptPassword) GetParameters(cryptedPassword string) (
 }
 
 func PreparePassword(password string) string {
-	return fmt.Sprintf("%s\x00%s", config.LoadableConfig.PasswordNonce, password)
+	return fmt.Sprintf("%s\x00%s", config.LoadableConfig.Server.Redis.PasswordNonce, password)
 }
 
 // GetHash creates an SHA-256 hash of a plain text password and returns the first 128 bits.


### PR DESCRIPTION
The configuration of certain secret keys and session management has been refactored. The handling of CSRFSecret, CookieStoreAuthKey, CookieStoreEncKey and PasswordNonce has been moved under specific configurations (Frontend and Redis). Frontend related setup and endpoints are only initialized if the frontend is enabled in the configuration. This makes the server configuration more organized and clearer to manage.