### PR TITLE
Update condition for Redis replica client creation

### DIFF
--- a/server/rediscli/cient.go
+++ b/server/rediscli/cient.go
@@ -136,8 +136,10 @@ func NewRedisReplicaClient() redis.UniversalClient {
 		return newRedisFailoverClient(redisCfg, true)
 	}
 
-	if redisCfg.Master.Address != redisCfg.Replica.Address {
-		return newRedisClient(redisCfg, redisCfg.Replica.Address)
+	if redisCfg.Replica.Address != "" {
+		if redisCfg.Master.Address != redisCfg.Replica.Address {
+			return newRedisClient(redisCfg, redisCfg.Replica.Address)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The condition for creating a new Redis replica client has been updated to first check if the Replica.Address field is not empty. This ensures that we do not attempt to create a replica client unless a replica address is specified.