### PR TITLE
Add initial key expiry handling to monitoring.lua

### DIFF
--- a/server/lua-plugins.d/callback/callback.lua
+++ b/server/lua-plugins.d/callback/callback.lua
@@ -100,7 +100,7 @@ function nauthilus_run_callback()
                 local redis_key = "ntc:DS:" .. crypto.md5(result.user)
 
                 if is_cmd_noop then
-                    nauthilus.redis_expire(redis_key, 86400)
+                    nauthilus.redis_expire(redis_key, 3600)
                 else
                     -- Cleanup dovecot session
                     ---@type string deleted

--- a/server/lua-plugins.d/filters/monitoring.lua
+++ b/server/lua-plugins.d/filters/monitoring.lua
@@ -16,6 +16,21 @@ function nauthilus_call_filter(request)
         return nil
     end
 
+    ---@param redis_key string
+    ---@return void
+    local function set_initial_expiry(redis_key)
+        ---@type number length
+        ---@type string err_redis_hlen
+        local length, err_redis_hlen = nauthilus.redis_hlen(redis_key)
+        if err_redis_hlen ~= nil then
+            nauthilus.custom_log_add("reids_hlen_failure", err_redis_hlen)
+        else
+            if length == 1 then
+                nauthilus.redis_expire(redis_key, 3600)
+            end
+        end
+    end
+
     ---@param session string
     ---@param server string
     ---@return void
@@ -27,6 +42,8 @@ function nauthilus_call_filter(request)
         if err_redis_hset ~= nil then
             nauthilus.custom_log_add("reids_hset_failure", err_redis_hset)
         end
+
+        set_initial_expiry(redis_key)
     end
 
     local function get_server_from_sessions(session)


### PR DESCRIPTION
A function, set_initial_expiry, has been introduced to handle initial expiry time for a given redis key in the monitoring.lua file. This function gets called when a new session is established. Additionally, the expiry time for redis keys in callback.lua has been reduced from 24 hours (86400 seconds) to 1 hour (3600 seconds).