### PR TITLE
Add specific HTTP request header retrieval function

### DIFF
--- a/server/backend/lua.go
+++ b/server/backend/lua.go
@@ -161,6 +161,7 @@ func setupGlobals(luaRequest *LuaRequest, L *lua.LState, logs *lualib.CustomLogK
 	globals.RawSetString(global.LuaFnAddCustomLog, L.NewFunction(lualib.AddCustomLog(logs)))
 	globals.RawSetString(global.LuaFnSetStatusMessage, L.NewFunction(lualib.SetStatusMessage(&luaRequest.StatusMessage)))
 	globals.RawSetString(global.LuaFnGetAllHTTPRequestHeaders, L.NewFunction(lualib.GetAllHTTPRequestHeaders(luaRequest.HTTPClientContext.Request)))
+	globals.RawSetString(global.LuaFnGetHTTPRequestHeader, L.NewFunction(lualib.GetHTTPRequestHeader(luaRequest.HTTPClientContext.Request)))
 
 	lualib.SetUPContextFunctions(luaRequest.Context, globals, L)
 	lualib.SetUPRedisFunctions(globals, L)

--- a/server/global/const.go
+++ b/server/global/const.go
@@ -961,6 +961,9 @@ const (
 	// LuaFnGetAllHTTPRequestHeaders represents the function name for "get_all_http_request_headers" in Lua
 	LuaFnGetAllHTTPRequestHeaders = "get_all_http_request_headers"
 
+	// LuaFnGetHTTPRequestHeader represents the function name for "get_http_request_header" in Lua
+	LuaFnGetHTTPRequestHeader = "get_http_request_header"
+
 	// LuaFnGetHTTPRequestBody represents the function name for "get_http_request_body" in Lua
 	LuaFnGetHTTPRequestBody = "get_http_request_body"
 

--- a/server/lua-plugins.d/callback/callback.lua
+++ b/server/lua-plugins.d/callback/callback.lua
@@ -9,26 +9,18 @@ local json = require("json")
 
 ------@return void
 function nauthilus_run_callback()
-    ---@type table headers
-    local headers = nauthilus.get_all_http_request_headers()
+    ---@type table header
+    local header = nauthilus.get_http_request_header("Content-Type")
 
     ---@type table request
     local body = nauthilus.get_http_request_body()
 
+    if #header == 1 and header[1] ~= "application/json" then
+        return
+    end
+
     ---@type boolean match_ct
     local match_ct = false
-
-    ---@param header_name string
-    ---@param header_values table
-    for header_name, header_values in pairs(headers) do
-        if header_name == "content-type" then
-            if header_values[1] ~= "application/json" then
-                return
-            end
-
-            match_ct = true
-        end
-    end
 
     if match_ct then
         ---@type table body_table

--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -249,6 +249,7 @@ func (aw *Worker) setupGlobals(L *lua.LState, logs *lualib.CustomLogKeyValue, ht
 
 	globals.RawSetString(global.LuaFnAddCustomLog, L.NewFunction(lualib.AddCustomLog(logs)))
 	globals.RawSetString(global.LuaFnGetAllHTTPRequestHeaders, L.NewFunction(lualib.GetAllHTTPRequestHeaders(httpRequest)))
+	globals.RawSetString(global.LuaFnGetHTTPRequestHeader, L.NewFunction(lualib.GetHTTPRequestHeader(httpRequest)))
 
 	lualib.SetUPContextFunctions(aw.luaActionRequest.Context, globals, L)
 	lualib.SetUPRedisFunctions(globals, L)

--- a/server/lualib/callback/callback.go
+++ b/server/lualib/callback/callback.go
@@ -236,6 +236,7 @@ func setupGlobals(ctx *gin.Context, L *lua.LState) *lua.LTable {
 	globals := L.NewTable()
 
 	globals.RawSetString(global.LuaFnGetAllHTTPRequestHeaders, L.NewFunction(lualib.GetAllHTTPRequestHeaders(ctx.Request)))
+	globals.RawSetString(global.LuaFnGetHTTPRequestHeader, L.NewFunction(lualib.GetHTTPRequestHeader(ctx.Request)))
 	globals.RawSetString(global.LuaFnGetHTTPRequestBody, L.NewFunction(getHTTPRequestBody(ctx.Request)))
 
 	lualib.SetUPRedisFunctions(globals, L)

--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -215,6 +215,7 @@ func (r *Request) setGlobals(ctx *gin.Context, L *lua.LState) *lua.LTable {
 	globals.RawSetString(global.LuaFnAddCustomLog, L.NewFunction(lualib.AddCustomLog(r.Logs)))
 	globals.RawSetString(global.LuaFnSetStatusMessage, L.NewFunction(lualib.SetStatusMessage(&r.StatusMessage)))
 	globals.RawSetString(global.LuaFnGetAllHTTPRequestHeaders, L.NewFunction(lualib.GetAllHTTPRequestHeaders(ctx.Request)))
+	globals.RawSetString(global.LuaFnGetHTTPRequestHeader, L.NewFunction(lualib.GetHTTPRequestHeader(ctx.Request)))
 
 	lualib.SetUPContextFunctions(r.Context, globals, L)
 	lualib.SetUPRedisFunctions(globals, L)

--- a/server/lualib/filter/filter.go
+++ b/server/lualib/filter/filter.go
@@ -337,6 +337,7 @@ func setGlobals(ctx *gin.Context, r *Request, L *lua.LState, backendResult **lua
 	globals.RawSetString(global.LuaFnSetStatusMessage, L.NewFunction(lualib.SetStatusMessage(&r.StatusMessage)))
 	globals.RawSetString(global.LuaFnApplyBackendResult, L.NewFunction(applyBackendResult(backendResult)))
 	globals.RawSetString(global.LuaFnGetAllHTTPRequestHeaders, L.NewFunction(lualib.GetAllHTTPRequestHeaders(ctx.Request)))
+	globals.RawSetString(global.LuaFnGetHTTPRequestHeader, L.NewFunction(lualib.GetHTTPRequestHeader(ctx.Request)))
 
 	lualib.SetUPContextFunctions(r.Context, globals, L)
 	lualib.SetUPRedisFunctions(globals, L)


### PR DESCRIPTION
This update introduces a new Lua function `get_http_request_header` that retrieves a specific HTTP request header. The function is implemented across multiple Lua action handlers and plugins, enhancing request handling efficiency and precision. This flexibility allows plugins and handlers to request individual headers, rather than processing the entire header collection.