### PR TITLE
Add Dovecot userdb request acceptance in monitoring.lua

### DIFF
--- a/server/lua-plugins.d/filters/monitoring.lua
+++ b/server/lua-plugins.d/filters/monitoring.lua
@@ -146,5 +146,10 @@ function nauthilus_call_filter(request)
         return nauthilus.FILTER_ACCEPT, nauthilus.FILTER_RESULT_OK
     end
 
+    -- Dovecot userdb request
+    if request.authenticated and request.no_auth then
+        return nauthilus.FILTER_ACCEPT, nauthilus.FILTER_RESULT_OK
+    end
+
     return nauthilus.FILTER_REJECT, nauthilus.FILTER_RESULT_OK
 end


### PR DESCRIPTION
This update adds a conditional block for accepting Dovecot userdb requests in the monitoring filter script. It allows the request if the request is authenticated and no_auth is true, which further refines the criteria for accepting or rejecting requests.