### PR TITLE
Refactor error logging and session addition in lua-plugins

### DIFF
--- a/server/lua-plugins.d/actions/telegram.lua
+++ b/server/lua-plugins.d/actions/telegram.lua
@@ -212,7 +212,7 @@ function nauthilus_call_action(request)
     rt.post_telegram = true
     nauthilus.context_set("rt", rt)
 
-    nauthilus.context_set("action_telegram","ok")
+    nauthilus.context_set("action_telegram", "ok")
     nauthilus.custom_log_add("action_" .. log_prefix .. "telegram", "success")
 
     return nauthilus.ACTION_RESULT_OK

--- a/server/lua-plugins.d/filters/geoip.lua
+++ b/server/lua-plugins.d/filters/geoip.lua
@@ -129,7 +129,7 @@ function nauthilus_call_filter(request)
 
         nauthilus.context_set(fg, "ok")
         nauthilus.custom_log_add(fg, "success")
-	else
+    else
         -- We must restore a failed authentication flag!
         if not request.authenticated then
             return nauthilus.FILTER_REJECT, nauthilus.FILTER_RESULT_OK


### PR DESCRIPTION
This commit improves the clarity and conciseness of error logging in monitoring.lua by renaming 'failure' to 'error'. Extracted add_session invocation out of conditions to reduce redundancy. Additionally, some unnecessary server port variables were removed to tighten the code. Minor formatting fixes were also made in telegram.lua and geoip.lua.