### PR TITLE
Refactor logging initialization

### DIFF
--- a/server/backend/cache.go
+++ b/server/backend/cache.go
@@ -62,7 +62,7 @@ func LookupUserAccountFromRedis(username string) (accountName string, err error)
 // If the key does not exist in Redis, it returns isRedisErr=true and err=nil.
 // If there is an error retrieving the value from Redis, it returns isRedisErr=true and err.
 // Otherwise, it unmarshals the value into the cache pointer and returns isRedisErr=false and err=nil.
-// It also logs any error messages using the DefaultErrLogger.
+// It also logs any error messages using the Logger.
 func LoadCacheFromRedis[T RedisCache](key string, cache **T) (isRedisErr bool, err error) {
 	var redisValue []byte
 
@@ -71,7 +71,7 @@ func LoadCacheFromRedis[T RedisCache](key string, cache **T) (isRedisErr bool, e
 			return true, nil
 		}
 
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return true, err
 	}
@@ -79,7 +79,7 @@ func LoadCacheFromRedis[T RedisCache](key string, cache **T) (isRedisErr bool, e
 	*cache = new(T)
 
 	if err = json.Unmarshal(redisValue, *cache); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return
 	}
@@ -104,7 +104,7 @@ func SaveUserDataToRedis[T RedisCache](guid string, key string, ttl uint, cache 
 
 	redisValue, err := json.Marshal(cache)
 	if err != nil {
-		level.Error(logging.DefaultErrLogger).Log(
+		level.Error(logging.Logger).Log(
 			global.LogKeyGUID, guid,
 			global.LogKeyError, err,
 		)
@@ -114,7 +114,7 @@ func SaveUserDataToRedis[T RedisCache](guid string, key string, ttl uint, cache 
 
 	//nolint:lll // Ignore
 	if result, err = rediscli.WriteHandle.Set(context.Background(), key, redisValue, time.Duration(ttl)*time.Second).Result(); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(
+		level.Error(logging.Logger).Log(
 			global.LogKeyGUID, guid,
 			global.LogKeyError, err,
 		)
@@ -193,7 +193,7 @@ func GetWebAuthnFromRedis(uniqueUserId string) (user *User, err error) {
 	key := "as_webauthn:user:" + uniqueUserId
 
 	if redisValue, err = rediscli.ReadHandle.Get(context.Background(), key).Bytes(); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func GetWebAuthnFromRedis(uniqueUserId string) (user *User, err error) {
 	user = &User{}
 
 	if err = json.Unmarshal(redisValue, user); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func SaveWebAuthnToRedis(user *User, ttl uint) error {
 
 	redisValue, err := json.Marshal(user)
 	if err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return err
 	}
@@ -227,7 +227,7 @@ func SaveWebAuthnToRedis(user *User, ttl uint) error {
 
 	//nolint:lll // Ignore
 	if result, err = rediscli.WriteHandle.Set(context.Background(), key, redisValue, time.Duration(ttl)*time.Second).Result(); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 	}
 
 	util.DebugModule(global.DbgCache, "redis", result)

--- a/server/backend/ldap.go
+++ b/server/backend/ldap.go
@@ -538,7 +538,7 @@ func (l *LDAPPool) logConnectionInfo(guid *string, index int) {
 //	err := errors.New("connection error")
 //	l.logConnectionError(&guid, err)
 func (l *LDAPPool) logConnectionError(guid *string, err error) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		global.LogKeyLDAPPoolName, l.name,
 		global.LogKeyGUID, *guid,
 		global.LogKeyError, err,
@@ -569,7 +569,7 @@ func (l *LDAPPool) setIdleConnections(bind bool) (err error) {
 // Finally, it logs a warning message indicating that the pool has obtained free connections.
 func (l *LDAPPool) waitForFreeConnection(guid *string, ldapConnIndex int, ldapWaitGroup *sync.WaitGroup) {
 	if ldapConnIndex == global.LDAPPoolExhausted {
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyLDAPPoolName, l.name,
 			global.LogKeyGUID, *guid,
 			global.LogKeyMsg, "Pool exhausted. Waiting for a free connection")
@@ -577,7 +577,7 @@ func (l *LDAPPool) waitForFreeConnection(guid *string, ldapConnIndex int, ldapWa
 		// XXX: Very hard decision, but an exhausted pool needs a human interaction!
 		ldapWaitGroup.Wait()
 
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyLDAPPoolName, l.name,
 			global.LogKeyGUID, *guid,
 			global.LogKeyMsg, "Pool got free connections")
@@ -706,7 +706,7 @@ func (l *LDAPPool) connectAndBindIfNeeded(guid *string, index int) error {
 // The function takes a GUID string pointer and an error object as input parameters.
 // It logs the LDAP pool name, GUID, and the error encountered.
 func (l *LDAPPool) logConnectionFailed(guid *string, err error) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		global.LogKeyLDAPPoolName, l.name,
 		global.LogKeyGUID, *guid,
 		global.LogKeyError, err)
@@ -729,7 +729,7 @@ func (l *LDAPPool) checkConnection(guid *string, index int) (err error) {
 
 		l.conn[index].state = global.LDAPStateClosed
 
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyLDAPPoolName, l.name,
 			global.LogKeyGUID, *guid,
 			global.LogKeyMsg, fmt.Sprintf("Connection #%d is closed", index+1),
@@ -1221,7 +1221,7 @@ func (l *LDAPPool) processLookupSearchRequest(index int, ldapRequest *LDAPReques
 		}
 
 		if doLog {
-			level.Error(logging.DefaultErrLogger).Log(
+			level.Error(logging.Logger).Log(
 				global.LogKeyLDAPPoolName, l.name,
 				global.LogKeyGUID, *ldapRequest.GUID,
 				global.LogKeyError, ldapError.Error(),

--- a/server/backend/lua.go
+++ b/server/backend/lua.go
@@ -315,11 +315,11 @@ func handleReturnTypes(L *lua.LState, nret int, luaRequest *LuaRequest, logs *lu
 
 // processError logs the error and sends a LuaBackendResult with the error and the logs to the LuaRequest's LuaReplyChan.
 // It takes an error, a LuaRequest, and a logs slice of CustomLogKeyValue as parameters.
-// The error is logged at the Error level using the DefaultErrLogger.
+// The error is logged at the Error level using the Logger.
 // The logs contain the session GUID and the path to the Lua script.
 // Lastly, the LuaBackendResult is sent to the LuaRequest's LuaReplyChan.
 func processError(err error, luaRequest *LuaRequest, logs *lualib.CustomLogKeyValue) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		global.LogKeyGUID, luaRequest.Session,
 		"script", config.LoadableConfig.GetLuaScriptPath(),
 		global.LogKeyError, err,

--- a/server/config/file.go
+++ b/server/config/file.go
@@ -822,19 +822,19 @@ func (f *File) validateBackends() error {
 func (f *File) validateRBLs() error {
 	if f.RBLs != nil {
 		if f.RBLs.Threshold > math.MaxInt {
-			level.Warn(logging.DefaultLogger).Log(
+			level.Warn(logging.Logger).Log(
 				global.LogKeyWarning, "Please use a smaller RBL threshold!",
 				"rbl_threshold", f.RBLs.Threshold)
 		}
 
 		for _, rbl := range f.RBLs.Lists {
 			if rbl.Weight > math.MaxUint8 {
-				level.Warn(logging.DefaultLogger).Log(
+				level.Warn(logging.Logger).Log(
 					global.LogKeyWarning, "Please use a lower RBL weight!",
 					"rbl_threshold", rbl.Weight,
 					"rbl", rbl.RBL)
 			} else if rbl.Weight < -math.MaxUint8 {
-				level.Warn(logging.DefaultLogger).Log(
+				level.Warn(logging.Logger).Log(
 					global.LogKeyWarning, "Please use a higher RBL weight!",
 					"rbl_threshold", rbl.Weight,
 					"rbl", rbl.RBL)
@@ -982,7 +982,7 @@ func (f *File) LDAPHavePoolOnly() bool {
 //
 // The method uses the EnvConfig and Backend structs defined in the codebase.
 // The Backend constants from the global package are also used for comparison.
-// The method logs debug information using the DefaultLogger from the logging package.
+// The method logs debug information using the Logger from the logging package.
 // The errors package is used to define and return the error messages.
 func (f *File) validatePassDBBackends() error {
 	for _, backend := range f.Server.Backends {
@@ -1724,7 +1724,7 @@ func ReloadConfigFile() (err error) {
 	// Replace existing configuration
 	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&LoadableConfig)), unsafe.Pointer(newCfgReload))
 
-	level.Info(logging.DefaultLogger).Log(global.LogKeyMsg, "Reloading configuration file finished")
+	level.Info(logging.Logger).Log(global.LogKeyMsg, "Reloading configuration file finished")
 
 	return
 }

--- a/server/config/server.go
+++ b/server/config/server.go
@@ -38,6 +38,7 @@ type BasicAuth struct {
 
 type Log struct {
 	JSON       bool         `mapstructure:"json"`
+	Color      bool         `mapstructure:"color"`
 	Level      Verbosity    `mapstructure:"level"`
 	DbgModules []*DbgModule `mapstructure:"debug_modules"`
 }

--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -688,11 +688,11 @@ func setUserInfoHeaders(ctx *gin.Context, a *AuthState) {
 }
 
 // handleLogging logs information about the authentication request if the verbosity level is greater than LogLevelWarn.
-// It uses the logging.DefaultLogger to log the information.
+// It uses the logging.Logger to log the information.
 // The logged information includes the result of the a.LogLineMail() function, which returns either "ok" or an empty string depending on the value of a.NoAuth,
 // and the path of the request URL obtained from ctx.Request.URL.Path.
 func handleLogging(ctx *gin.Context, a *AuthState) {
-	level.Info(logging.DefaultLogger).Log(a.LogLineMail(func() string {
+	level.Info(logging.Logger).Log(a.LogLineMail(func() string {
 		if !a.NoAuth {
 			return "ok"
 		}
@@ -762,7 +762,7 @@ func (a *AuthState) setFailureHeaders(ctx *gin.Context) {
 //	ctx := &gin.Context{}
 //	a.loginAttemptProcessing(ctx)
 func (a *AuthState) loginAttemptProcessing(ctx *gin.Context) {
-	level.Info(logging.DefaultLogger).Log(a.LogLineMail("fail", ctx.Request.URL.Path)...)
+	level.Info(logging.Logger).Log(a.LogLineMail("fail", ctx.Request.URL.Path)...)
 
 	stats.LoginsCounter.WithLabelValues(global.LabelFailure).Inc()
 }
@@ -854,7 +854,7 @@ func (a *AuthState) authTempFail(ctx *gin.Context, reason string) {
 	}
 
 	ctx.String(a.StatusCodeInternalError, a.StatusMessage)
-	level.Info(logging.DefaultLogger).Log(a.LogLineMail("tempfail", ctx.Request.URL.Path)...)
+	level.Info(logging.Logger).Log(a.LogLineMail("tempfail", ctx.Request.URL.Path)...)
 }
 
 // isMasterUser checks whether the current user is a master user based on the MasterUser configuration in the LoadableConfig.
@@ -914,7 +914,7 @@ func (a *AuthState) isInNetwork(networkList []string) (matchIP bool) {
 // Usage example:
 // a.logNetworkError(ipOrNet, err)
 func (a *AuthState) logNetworkError(ipOrNet string, err error) {
-	level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyMsg, "%s is not a network", ipOrNet, global.LogKeyError, err)
+	level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyMsg, "%s is not a network", ipOrNet, global.LogKeyError, err)
 }
 
 // checkAndLogNetwork logs the information about checking a network for the given authentication object.
@@ -1004,7 +1004,7 @@ func logDebugModule(a *AuthState, passDB *PassDBMap, passDBResult *PassDBResult)
 // handleBackendErrors handles the errors that occur during backend processing.
 // It checks if the error is a configuration error for SQL, LDAP, or Lua backends and adds them to the configErrors map.
 // If all password databases have been processed and there are configuration errors, it calls the checkAllBackends function.
-// If the error is not a configuration error, it logs the error using the DefaultErrLogger.
+// If the error is not a configuration error, it logs the error using the Logger.
 // It returns the error unchanged.
 func handleBackendErrors(passDBIndex int, passDBs []*PassDBMap, passDB *PassDBMap, err error, a *AuthState, configErrors map[global.Backend]error) error {
 	if errors.Is(err, errors2.ErrLDAPConfig) || errors.Is(err, errors2.ErrLuaConfig) {
@@ -1015,7 +1015,7 @@ func handleBackendErrors(passDBIndex int, passDBs []*PassDBMap, passDB *PassDBMa
 			err = checkAllBackends(configErrors, a)
 		}
 	} else {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, "passdb", passDB.backend.String(), global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, "passdb", passDB.backend.String(), global.LogKeyError, err)
 	}
 
 	return err
@@ -1036,7 +1036,7 @@ func checkAllBackends(configErrors map[global.Backend]error, a *AuthState) (err 
 	// If all (real) Database backends failed, we must return with a temporary failure
 	if allConfigErrors {
 		err = errors2.ErrAllBackendConfigError
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, "passdb", "all", global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, "passdb", "all", global.LogKeyError, err)
 	}
 
 	return err
@@ -1493,9 +1493,9 @@ func (a *AuthState) postVerificationProcesses(ctx *gin.Context, useCache bool, b
 				logs = append(logs, a.AdditionalLogs...)
 			}
 
-			level.Error(logging.DefaultErrLogger).Log(logs...)
+			level.Error(logging.Logger).Log(logs...)
 		} else {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
+			level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
 		}
 
 		return global.AuthResultTempFail
@@ -1524,7 +1524,7 @@ func (a *AuthState) postVerificationProcesses(ctx *gin.Context, useCache bool, b
 
 					accountName, err = a.getUserAccountFromRedis()
 					if err != nil {
-						level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
+						level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
 
 						return global.AuthResultTempFail
 					}
@@ -1681,7 +1681,7 @@ func (a *AuthState) filterLua(passDBResult *PassDBResult, ctx *gin.Context) glob
 	filterResult, luaBackendResult, removeAttributes, err := filterRequest.CallFilterLua(ctx)
 	if err != nil {
 		if !errors.Is(err, errors2.ErrNoFiltersDefined) {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
+			level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
 
 			return global.AuthResultTempFail
 		}
@@ -1760,12 +1760,12 @@ func (a *AuthState) listUserAccounts() (accountList AccountList) {
 		} else {
 			var detailedError *errors2.DetailedError
 			if errors.As(err, &detailedError) {
-				level.Error(logging.DefaultErrLogger).Log(
+				level.Error(logging.Logger).Log(
 					global.LogKeyGUID, a.GUID,
 					global.LogKeyError, detailedError.Error(),
 					global.LogKeyErrorDetails, detailedError.GetDetails())
 			} else {
-				level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err)
+				level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err)
 			}
 		}
 	}
@@ -2110,7 +2110,7 @@ func NewAuthState(ctx *gin.Context) *AuthState {
 	if err := auth.setStatusCodes(ctx.Param("service")); err != nil {
 		guid := ctx.GetString(global.CtxGUIDKey)
 
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 
 		return nil
 	}
@@ -2173,7 +2173,7 @@ func (a *AuthState) withClientInfo(ctx *gin.Context) *AuthState {
 		// This might be valid, if HAproxy v2 support is enabled
 		a.ClientIP, a.XClientPort, err = net.SplitHostPort(ctx.Request.RemoteAddr)
 		if err != nil {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
+			level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
 		}
 
 		a.ClientIP, a.XClientPort = util.GetProxyAddress(ctx.Request, a.ClientIP, a.XClientPort)
@@ -2255,7 +2255,7 @@ func (a *AuthState) processClaim(claimName string, claimValue string, claims map
 			}
 		}
 
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyGUID, a.GUID,
 			global.LogKeyWarning, fmt.Sprintf("Claim '%s' malformed or not returned from database", claimName),
 		)
@@ -2278,7 +2278,7 @@ func applyClaim(claimKey string, attributeKey string, a *AuthState, claims map[s
 	}
 
 	if !success {
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyGUID, a.GUID,
 			global.LogKeyWarning, fmt.Sprintf("Claim '%s' malformed or not returned from Database", claimKey),
 		)
@@ -2418,7 +2418,7 @@ func (a *AuthState) applyClientClaimHandlers(client *config.Oauth2Client, claims
 // - `config.LoadableConfig.Oauth2.Clients`: The OAuth2 clients configuration.
 // - `a.Attributes`: The AuthState object's Attributes map.
 // - `util.DebugModule`: A function for logging debug messages.
-// - `global.DbgModule`, `global.LogKeyGUID`, `global.ClaimGroups`, `logging.DefaultLogger`, `global.LogKeyWarning`: Various declarations used internally in the method.
+// - `global.DbgModule`, `global.LogKeyGUID`, `global.ClaimGroups`, `logging.Logger`, `global.LogKeyWarning`: Various declarations used internally in the method.
 func (a *AuthState) processGroupsClaim(index int, claims map[string]any) {
 	valueApplied := false
 
@@ -2443,7 +2443,7 @@ func (a *AuthState) processGroupsClaim(index int, claims map[string]any) {
 		}
 
 		if !valueApplied {
-			level.Warn(logging.DefaultLogger).Log(
+			level.Warn(logging.Logger).Log(
 				global.LogKeyGUID, a.GUID,
 				global.LogKeyWarning, fmt.Sprintf("Claim '%s' malformed or not returned from Database", global.ClaimGroups),
 			)
@@ -2536,7 +2536,7 @@ func (a *AuthState) processCustomClaims(scopeIndex int, oauth2Client openapi.OAu
 			}
 
 			if !valueTypeMatch {
-				level.Error(logging.DefaultErrLogger).Log(
+				level.Error(logging.Logger).Log(
 					global.LogKeyGUID, a.GUID,
 					"custom_claim_name", customClaimName,
 					global.LogKeyError, fmt.Sprintf("Unknown type '%s'", customClaimType),
@@ -2591,7 +2591,7 @@ func (a *AuthState) getOauth2SubjectAndClaims(oauth2Client openapi.OAuth2Client)
 			var value []any
 
 			if value, okay = a.Attributes[client.Subject]; !okay {
-				level.Info(logging.DefaultLogger).Log(
+				level.Info(logging.Logger).Log(
 					global.LogKeyGUID, a.GUID,
 					global.LogKeyMsg, fmt.Sprintf(
 						"Attributes did not contain requested field '%s'",
@@ -2613,7 +2613,7 @@ func (a *AuthState) getOauth2SubjectAndClaims(oauth2Client openapi.OAuth2Client)
 		}
 
 		if !clientIDFound {
-			level.Warn(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyMsg, "No client_id section found")
+			level.Warn(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyMsg, "No client_id section found")
 		}
 	} else {
 		// Default result, if no oauth2/clients definition is found

--- a/server/core/features.go
+++ b/server/core/features.go
@@ -82,7 +82,7 @@ func (a *AuthState) featureLua(ctx *gin.Context) (triggered bool, abortFeatures 
 
 		return
 	} else {
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.FeatureLua, "localhost")
+		level.Info(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.FeatureLua, "localhost")
 	}
 
 	return
@@ -98,7 +98,7 @@ func (a *AuthState) featureTLSEncryption() (triggered bool) {
 		if a.XSSL == global.NotAvailable {
 			matchIP := a.isInNetwork(config.LoadableConfig.ClearTextList)
 			if !matchIP {
-				level.Info(logging.DefaultLogger).Log(
+				level.Info(logging.Logger).Log(
 					global.LogKeyGUID, a.GUID,
 					global.FeatureTLSEncryption, "Client has no transport security",
 					global.LogKeyClientIP, a.ClientIP,
@@ -109,13 +109,13 @@ func (a *AuthState) featureTLSEncryption() (triggered bool) {
 				return
 			}
 
-			level.Info(logging.DefaultLogger).Log(
+			level.Info(logging.Logger).Log(
 				global.LogKeyGUID, a.GUID,
 				global.FeatureTLSEncryption, "Client is whitelisted",
 				global.LogKeyClientIP, a.ClientIP)
 		}
 	} else {
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.FeatureTLSEncryption, "localhost")
+		level.Info(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.FeatureTLSEncryption, "localhost")
 	}
 
 	return
@@ -149,13 +149,13 @@ func (a *AuthState) featureRelayDomains() (triggered bool) {
 					}
 				}
 
-				level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.FeatureRelayDomains, fmt.Sprintf("%s not our domain", split[1]))
+				level.Info(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.FeatureRelayDomains, fmt.Sprintf("%s not our domain", split[1]))
 
 				triggered = true
 			}
 		}
 	} else {
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.FeatureRelayDomains, "localhost")
+		level.Info(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.FeatureRelayDomains, "localhost")
 	}
 
 	return
@@ -208,7 +208,7 @@ func (a *AuthState) featureRBLs(ctx *gin.Context) (triggered bool, err error) {
 								dnsResolverErr.Store(true)
 							}
 
-							level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, errRBL)
+							level.Error(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, errRBL)
 						}
 
 						rblChan <- 0
@@ -217,7 +217,7 @@ func (a *AuthState) featureRBLs(ctx *gin.Context) (triggered bool, err error) {
 					}
 
 					if isListed {
-						level.Info(logging.DefaultLogger).Log(
+						level.Info(logging.Logger).Log(
 							global.LogKeyGUID, a.GUID,
 							global.FeatureRBL, "RBL matched",
 							global.LogKeyClientIP, a.ClientIP,
@@ -254,12 +254,12 @@ func (a *AuthState) featureRBLs(ctx *gin.Context) (triggered bool, err error) {
 				}
 			}
 		} else {
-			level.Info(logging.DefaultLogger).Log(
+			level.Info(logging.Logger).Log(
 				global.LogKeyGUID, a.GUID, global.FeatureRBL, "Client is whitelisted", global.LogKeyClientIP, a.ClientIP,
 			)
 		}
 	} else {
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.FeatureRBL, "localhost")
+		level.Info(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.FeatureRBL, "localhost")
 	}
 
 	if totalRBLScore >= config.LoadableConfig.RBLs.Threshold {

--- a/server/core/http.go
+++ b/server/core/http.go
@@ -230,7 +230,7 @@ func basicAuthMiddleware() gin.HandlerFunc {
 
 		// Note: Chicken-egg problem.
 		if ctx.Param("category") == global.CatHTTP && ctx.Param("service") == global.ServBasicAuth {
-			level.Warn(logging.DefaultLogger).Log(
+			level.Warn(logging.Logger).Log(
 				global.LogKeyGUID, guid,
 				global.LogKeyWarning, "Disabling HTTP basic Auth",
 				"category", ctx.Param("category"),
@@ -271,7 +271,7 @@ func basicAuthMiddleware() gin.HandlerFunc {
 // It then proceeds to the next middleware or handler in the chain by calling ctx.Next().
 // After the request is processed, it checks for any errors in the context using ctx.Errors.Last().
 // Based on the presence of an error, it decides which logger, logWrapper, and logKey to use.
-// The logger is either logging.DefaultErrLogger or logging.DefaultLogger.
+// The logger is either logging.Logger or logging.Logger.
 // The logWrapper is either level.Error or level.Info.
 // The logKey is either global.LogKeyError or global.LogKeyMsg.
 // The function stops the timer and calculates the latency.
@@ -299,11 +299,11 @@ func loggerMiddleware() gin.HandlerFunc {
 
 		// Decide which logger to use
 		if err != nil {
-			logger = logging.DefaultErrLogger
+			logger = logging.Logger
 			logWrapper = level.Error
 			logKey = global.LogKeyError
 		} else {
-			logger = logging.DefaultLogger
+			logger = logging.Logger
 			logWrapper = level.Info
 			logKey = global.LogKeyMsg
 		}
@@ -711,7 +711,7 @@ func HTTPApp(ctx context.Context) {
 
 	webAuthn, err = setupWebAuthn()
 	if err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyMsg, "Failed to create WebAuthn from EnvConfig", global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyMsg, "Failed to create WebAuthn from EnvConfig", global.LogKeyError, err)
 
 		os.Exit(-1)
 	}
@@ -790,7 +790,7 @@ func HTTPApp(ctx context.Context) {
 	}
 
 	if !errors.Is(err, http.ErrServerClosed) {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		os.Exit(1)
 	}

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -480,7 +480,7 @@ func processErrorLogging(ctx *gin.Context, err error) {
 }
 
 // logError logs the error details along with the corresponding GUID, client IP, and error message.
-// If the error is of type *errors2.DetailedError, it logs the error details using logging.DefaultErrLogger.Log method.
+// If the error is of type *errors2.DetailedError, it logs the error details using logging.Logger.Log method.
 // Otherwise, it logs only the error message.
 //
 // ctx: The Gin context.
@@ -491,14 +491,14 @@ func logError(ctx *gin.Context, err error) {
 	guid := ctx.GetString(global.CtxGUIDKey)
 
 	if errors.As(err, &detailedError) {
-		level.Error(logging.DefaultErrLogger).Log(
+		level.Error(logging.Logger).Log(
 			global.LogKeyGUID, guid,
 			global.LogKeyError, (*detailedError).Error(),
 			global.LogKeyErrorDetails, (*detailedError).GetDetails(),
 			global.LogKeyClientIP, ctx.Request.RemoteAddr,
 		)
 	} else {
-		level.Error(logging.DefaultErrLogger).Log(
+		level.Error(logging.Logger).Log(
 			global.LogKeyGUID, guid,
 			global.LogKeyError, err,
 			global.LogKeyClientIP, ctx.Request.RemoteAddr,
@@ -577,7 +577,7 @@ func getLocalized(ctx *gin.Context, messageID string) string {
 	}
 	localization, err := localizer.Localize(&localizeConfig)
 	if err != nil {
-		level.Error(logging.DefaultErrLogger).Log(
+		level.Error(logging.Logger).Log(
 			global.LogKeyGUID, ctx.GetString(global.CtxGUIDKey),
 			"message_id", messageID, global.LogKeyError, err.Error(),
 		)
@@ -1068,7 +1068,7 @@ func (a *ApiConfig) handleLoginNoSkip() {
 
 // logInfoLoginSkip logs the login skip event with the provided details.
 func (a *ApiConfig) logInfoLoginSkip(redirectTo string) {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeySkip, true,
 		global.LogKeyClientID, *a.clientId,
@@ -1083,7 +1083,7 @@ func (a *ApiConfig) logInfoLoginSkip(redirectTo string) {
 
 // logInfoLoginNoSkip logs information about the login operation without skipping any step.
 func (a *ApiConfig) logInfoLoginNoSkip() {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeySkip, false,
 		global.LogKeyClientID, *a.clientId,
@@ -1297,7 +1297,7 @@ func (a *ApiConfig) getSubjectAndClaims(account string, auth *AuthState) (string
 	if subject == "" {
 		subject = account
 
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyGUID, a.guid,
 			global.LogKeyMsg, fmt.Sprintf("Empty 'subject', using '%s' as value", account),
 		)
@@ -1453,7 +1453,7 @@ func (a *ApiConfig) logInfoLoginAccept(subject string, redirectTo string, auth *
 		logs = append(logs, auth.AdditionalLogs...)
 	}
 
-	level.Info(logging.DefaultLogger).Log(logs...)
+	level.Info(logging.Logger).Log(logs...)
 }
 
 // totpValidation validates the time-based one-time password (TOTP) code against the provided account and TOTP secret.
@@ -1619,7 +1619,7 @@ func (a *ApiConfig) logFailedLoginAndRedirect(auth *AuthState) {
 		logs = append(logs, auth.AdditionalLogs...)
 	}
 
-	level.Info(logging.DefaultLogger).Log(logs...)
+	level.Info(logging.Logger).Log(logs...)
 }
 
 // Page '/login/post'
@@ -1821,7 +1821,7 @@ func deviceGETHandler(ctx *gin.Context) {
 
 	ctx.HTML(http.StatusOK, "device.html", loginData)
 
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, guid,
 		global.LogKeySkip, false,
 		global.LogKeyClientID, *clientId,
@@ -2149,7 +2149,7 @@ func (a *ApiConfig) redirectWithConsent() {
 
 // logInfoConsent logs information about the consent request.
 func (a *ApiConfig) logInfoConsent() {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeySkip, false,
 		global.LogKeyClientID, *a.clientId,
@@ -2163,7 +2163,7 @@ func (a *ApiConfig) logInfoConsent() {
 // logInfoRedirectWithConsent logs an info level message with the given parameters
 // to the default logger.
 func (a *ApiConfig) logInfoRedirectWithConsent(redirectTo string) {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeySkip, true,
 		global.LogKeyClientID, *a.clientId,
@@ -2392,7 +2392,7 @@ func (a *ApiConfig) processConsentReject() {
 
 // logInfoConsentAccept logs an info level log message for accepting the consent and redirects to the specified URL.
 func (a *ApiConfig) logInfoConsentAccept(redirectTo string) {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeyClientID, *a.clientId,
 		global.LogKeyClientName, a.clientName,
@@ -2406,7 +2406,7 @@ func (a *ApiConfig) logInfoConsentAccept(redirectTo string) {
 
 // logInfoConsentReject logs the information about a rejected consent request.
 func (a *ApiConfig) logInfoConsentReject(redirectTo *string) {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeyClientID, *a.clientId,
 		global.LogKeyClientName, a.clientName,
@@ -2504,7 +2504,7 @@ func (a *ApiConfig) handleLogout() {
 
 // logInfoLogout logs information about a logout action.
 func (a *ApiConfig) logInfoLogout() {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeyAuthSubject, a.logoutRequest.GetSubject(),
 		global.LogKeyAuthChallenge, a.challenge,
@@ -2650,7 +2650,7 @@ func (a *ApiConfig) rejectLogout() {
 
 // logInfoLogoutAccept logs information about the logout request acceptance.
 func (a *ApiConfig) logInfoLogoutAccept(redirectTo string) {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeyAuthSubject, a.logoutRequest.GetSubject(),
 		global.LogKeyAuthChallenge, a.challenge,
@@ -2662,7 +2662,7 @@ func (a *ApiConfig) logInfoLogoutAccept(redirectTo string) {
 
 // logInfoLogoutReject logs an info-level message indicating a rejected logout attempt.
 func (a *ApiConfig) logInfoLogoutReject(redirectTo string) {
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, a.guid,
 		global.LogKeyAuthSubject, a.logoutRequest.GetSubject(),
 		global.LogKeyAuthChallenge, a.challenge,
@@ -2890,7 +2890,7 @@ func handleIntegerClaimType(claimDict map[string]any, customClaimName string) (i
 
 // Logs error for unknown claim type
 func logUnknownClaimTypeError(customClaimName string, customClaimType string) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		"custom_claim_name", customClaimName,
 		global.LogKeyError, fmt.Sprintf("Unknown type '%s'", customClaimType),
 	)

--- a/server/core/ldap.go
+++ b/server/core/ldap.go
@@ -226,7 +226,7 @@ func ldapPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 		if ldapReply.Err != nil {
 			var ldapError *ldap.Error
 
-			level.Debug(logging.DefaultLogger).Log(global.LogKeyGUID, auth.GUID, global.LogKeyMsg, err)
+			level.Debug(logging.Logger).Log(global.LogKeyGUID, auth.GUID, global.LogKeyMsg, err)
 
 			if errors.As(err, &ldapError) {
 				if ldapError.ResultCode != uint16(ldap.LDAPResultInvalidCredentials) {

--- a/server/core/register.go
+++ b/server/core/register.go
@@ -167,7 +167,7 @@ func displayLoginpage(ctx *gin.Context, languageCurrentName string, languagePass
 
 	ctx.HTML(http.StatusOK, "login.html", loginData)
 
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, guid,
 		global.LogKeyUriPath, global.TwoFAv1Root+viper.GetString("login_2fa_page"),
 	)
@@ -392,7 +392,7 @@ func processTwoFARedirect(ctx *gin.Context, authComplete bool) {
 
 	ctx.Redirect(http.StatusFound, targetURI)
 
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, guid,
 		global.LogKeyUsername, ctx.PostForm("username"),
 		global.LogKeyAuthStatus, global.LogKeyAuthAccept,
@@ -475,7 +475,7 @@ func handleAuthFailureAndRedirect(ctx *gin.Context, auth *AuthState) {
 		global.TwoFAv1Root+viper.GetString("login_2fa_page")+"?_error="+global.PasswordFail,
 	)
 
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, guid,
 		global.LogKeyUsername, ctx.PostForm("username"),
 		global.LogKeyAuthStatus, global.LogKeyAuthReject,
@@ -691,7 +691,7 @@ func registerTotpPOSTHandler(ctx *gin.Context) {
 	}
 
 	if config.LoadableConfig.Server.Log.Level.Level() >= global.LogLevelDebug && config.EnvConfig.DevMode {
-		level.Debug(logging.DefaultLogger).Log(
+		level.Debug(logging.Logger).Log(
 			global.LogKeyGUID, guid,
 			"totp_key", fmt.Sprintf("%+v", totpKey),
 		)
@@ -703,7 +703,7 @@ func registerTotpPOSTHandler(ctx *gin.Context) {
 			global.TwoFAv1Root+viper.GetString("totp_page")+"?_error="+global.InvalidCode,
 		)
 
-		level.Info(logging.DefaultLogger).Log(
+		level.Info(logging.Logger).Log(
 			global.LogKeyGUID, guid,
 			global.LogKeyUsername, ctx.PostForm("username"),
 			global.LogKeyAuthStatus, global.LogKeyAuthReject,
@@ -785,7 +785,7 @@ func registerTotpPOSTHandler(ctx *gin.Context) {
 					continue
 				}
 
-				level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+				level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 
 				break
 			}
@@ -801,7 +801,7 @@ func registerTotpPOSTHandler(ctx *gin.Context) {
 
 	ctx.Redirect(http.StatusFound, viper.GetString("notify_page")+"?message=OTP code is valid. Registration completed successfully")
 
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		global.LogKeyGUID, guid,
 		global.LogKeyUsername, ctx.PostForm("username"),
 		global.LogKeyAuthStatus, global.LogKeyAuthAccept,

--- a/server/core/rest.go
+++ b/server/core/rest.go
@@ -83,7 +83,7 @@ func (a *AuthState) generic(ctx *gin.Context) {
 			ctx.Data(http.StatusOK, "text/plain", []byte(account+"\r\n"))
 		}
 
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, a.GUID, global.LogKeyMode, mode)
+		level.Info(logging.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyMode, mode)
 	} else {
 		if !(a.NoAuth || ctx.GetBool(global.CtxLocalCacheAuthKey)) {
 			//nolint:exhaustive // Ignore some results
@@ -156,7 +156,7 @@ func (a *AuthState) callback(ctx *gin.Context) {
 
 // healthCheck handles the health check functionality by logging a message and returning "pong" as the response.
 func healthCheck(ctx *gin.Context) {
-	level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, ctx.GetString(global.CtxGUIDKey), global.LogKeyMsg, "Health check")
+	level.Info(logging.Logger).Log(global.LogKeyGUID, ctx.GetString(global.CtxGUIDKey), global.LogKeyMsg, "Health check")
 
 	ctx.String(http.StatusOK, "pong")
 }
@@ -180,7 +180,7 @@ func listBruteforce(ctx *gin.Context) {
 	result, err := rediscli.ReadHandle.HGetAll(context.Background(), key).Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+			level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 
 			httpStatusCode = http.StatusInternalServerError
 			list.Error = err.Error()
@@ -190,7 +190,7 @@ func listBruteforce(ctx *gin.Context) {
 			stats.RedisReadCounter.Inc()
 		}
 	} else {
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, global.ServList)
+		level.Info(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, global.ServList)
 
 		list.IPAddresses = result
 		list.Error = "none"
@@ -235,10 +235,10 @@ func flushCache(ctx *gin.Context) {
 	guid := ctx.GetString(global.CtxGUIDKey)
 	userCmd := &FlushUserCmd{}
 
-	level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.CatCache, global.ServFlush)
+	level.Info(logging.Logger).Log(global.LogKeyGUID, guid, global.CatCache, global.ServFlush)
 
 	if err := ctx.BindJSON(userCmd); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 		ctx.AbortWithStatus(http.StatusBadRequest)
 
 		return
@@ -387,7 +387,7 @@ func removeUserFromCache(userCmd *FlushUserCmd, userKeys config.StringSet, guid 
 	}
 
 	if err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 
 		return
 	}
@@ -396,14 +396,14 @@ func removeUserFromCache(userCmd *FlushUserCmd, userKeys config.StringSet, guid 
 
 	for _, userKey := range userKeys.GetStringSlice() {
 		if _, err = rediscli.WriteHandle.Del(context.Background(), userKey).Result(); err != nil {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+			level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 
 			return
 		}
 
 		stats.RedisWriteCounter.Inc()
 
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, "keys", userKey, "status", "flushed")
+		level.Info(logging.Logger).Log(global.LogKeyGUID, guid, "keys", userKey, "status", "flushed")
 	}
 }
 
@@ -424,10 +424,10 @@ func removeUserFromCache(userCmd *FlushUserCmd, userKeys config.StringSet, guid 
 //	   guid := ctx.GetString(global.CtxGUIDKey)
 //	   userCmd := &FlushUserCmd{}
 //
-//	   level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.CatCache, global.ServFlush)
+//	   level.Info(logging.Logger).Log(global.LogKeyGUID, guid, global.CatCache, global.ServFlush)
 //
 //	   if err := ctx.BindJSON(userCmd); err != nil {
-//	       level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+//	       level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 //	       ctx.AbortWithStatus(http.StatusBadRequest)
 //	       return
 //	   }
@@ -443,7 +443,7 @@ func removeUserFromCache(userCmd *FlushUserCmd, userKeys config.StringSet, guid 
 //	}
 func sendCacheStatus(ctx *gin.Context, guid string, userCmd *FlushUserCmd, useCache bool, statusMsg string) {
 	if useCache {
-		level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, statusMsg)
+		level.Info(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, statusMsg)
 
 		ctx.JSON(http.StatusOK, &RESTResult{
 			GUID:      guid,
@@ -457,7 +457,7 @@ func sendCacheStatus(ctx *gin.Context, guid string, userCmd *FlushUserCmd, useCa
 	} else {
 		msg := "Cache backend not enabled"
 
-		level.Warn(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, msg)
+		level.Warn(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, msg)
 
 		ctx.JSON(http.StatusInternalServerError, &RESTResult{
 			GUID:      guid,
@@ -483,22 +483,22 @@ func flushBruteForceRule(ctx *gin.Context) {
 	guid := ctx.GetString(global.CtxGUIDKey)
 	statusMsg := "flushed"
 
-	level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.CatBruteForce, global.ServFlush)
+	level.Info(logging.Logger).Log(global.LogKeyGUID, guid, global.CatBruteForce, global.ServFlush)
 
 	ipCmd := &FlushRuleCmd{}
 
 	if err = ctx.BindJSON(ipCmd); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 		ctx.AbortWithStatus(http.StatusBadRequest)
 
 		return
 	}
 
-	level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, "ip_address", ipCmd.IPAddress)
+	level.Info(logging.Logger).Log(global.LogKeyGUID, guid, "ip_address", ipCmd.IPAddress)
 
 	ruleFlushError, err = processBruteForceRules(ctx, ipCmd, guid)
 	if err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyError, err)
 		ctx.AbortWithStatus(http.StatusInternalServerError)
 
 		return
@@ -508,7 +508,7 @@ func flushBruteForceRule(ctx *gin.Context) {
 		statusMsg = "not flushed"
 	}
 
-	level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, statusMsg)
+	level.Info(logging.Logger).Log(global.LogKeyGUID, guid, global.LogKeyMsg, statusMsg)
 
 	ctx.JSON(http.StatusOK, &RESTResult{
 		GUID:      guid,
@@ -562,7 +562,7 @@ func processBruteForceRules(ctx *gin.Context, ipCmd *FlushRuleCmd, guid string) 
 
 				stats.RedisWriteCounter.Inc()
 
-				level.Info(logging.DefaultLogger).Log(global.LogKeyGUID, guid, "key", key, "status", "flushed")
+				level.Info(logging.Logger).Log(global.LogKeyGUID, guid, "key", key, "status", "flushed")
 			}
 		}
 	}

--- a/server/core/statistics.go
+++ b/server/core/statistics.go
@@ -28,7 +28,7 @@ func getCounterValue(metric *prometheus.CounterVec, lvs ...string) float64 {
 	dtoMetric := &dto.Metric{}
 
 	if err := metric.WithLabelValues(lvs...).Write(dtoMetric); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return 0
 	}
@@ -53,12 +53,12 @@ func LoadStatsFromRedis() {
 	for _, counterType := range []string{global.LabelSuccess, global.LabelFailure} {
 		if redisValue, err = rediscli.ReadHandle.HGet(context.Background(), redisLoginsCounterKey, counterType).Float64(); err != nil {
 			if errors.Is(err, redis.Nil) {
-				level.Info(logging.DefaultLogger).Log(global.LogKeyMsg, "No statistics on Redis server")
+				level.Info(logging.Logger).Log(global.LogKeyMsg, "No statistics on Redis server")
 
 				return
 			}
 
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+			level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 			return
 		}
@@ -83,7 +83,7 @@ func SaveStatsToRedis() {
 
 	for index := range metrics {
 		if err = rediscli.WriteHandle.HSet(context.Background(), redisLoginsCounterKey, metrics[index].Label, metrics[index].Value).Err(); err != nil {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+			level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 			return
 		}

--- a/server/logging/logger_test.go
+++ b/server/logging/logger_test.go
@@ -1,0 +1,76 @@
+package logging
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/croessner/nauthilus/server/global"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+func TestSetupLogging(t *testing.T) {
+	tests := []struct {
+		name           string
+		configLogLevel int
+		formatJSON     bool
+		useColor       bool
+		instance       string
+	}{
+		{
+			name:           "LogLevelNone, JSON format, Color",
+			configLogLevel: global.LogLevelNone,
+			formatJSON:     true,
+			useColor:       true,
+			instance:       "none_json_color",
+		},
+		{
+			name:           "LogLevelError, Logfmt format, No Color",
+			configLogLevel: global.LogLevelError,
+			formatJSON:     false,
+			useColor:       false,
+			instance:       "error_logfmt_nocolor",
+		},
+		{
+			name:           "LogLevelWarn, JSON format, Color",
+			configLogLevel: global.LogLevelWarn,
+			formatJSON:     true,
+			useColor:       true,
+			instance:       "warn_json_color",
+		},
+		{
+			name:           "LogLevelInfo, Logfmt format, No Color",
+			configLogLevel: global.LogLevelInfo,
+			formatJSON:     false,
+			useColor:       false,
+			instance:       "info_logfmt_nocolor",
+		},
+		{
+			name:           "LogLevelDebug, JSON format, No color",
+			configLogLevel: global.LogLevelDebug,
+			formatJSON:     true,
+			useColor:       false,
+			instance:       "debug_json_nocolor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+
+			Logger = log.NewLogfmtLogger(log.NewSyncWriter(buf))
+
+			SetupLogging(tt.configLogLevel, tt.formatJSON, tt.useColor, tt.instance)
+
+			// testing log level
+			level.Debug(Logger).Log("msg", "debug")
+			level.Info(Logger).Log("msg", "info")
+			level.Warn(Logger).Log("msg", "warn")
+			level.Error(Logger).Log("msg", "error")
+
+			// testing instance
+			logTest := log.With(Logger, global.LogKeyInstance, tt.instance)
+			logTest.Log("msg", "instance test")
+		})
+	}
+}

--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -173,7 +173,7 @@ func (aw *Worker) loadScriptAction(actionConfig *config.LuaAction) {
 
 // loadScript loads a Lua script into a LuaScriptAction object.
 // It compiles the script using lualib.CompileLua and stores the compiled script in LuaScriptAction.ScriptCompiled.
-// If the compilation fails, it logs the error using logging.DefaultErrLogger.
+// If the compilation fails, it logs the error using logging.Logger.
 //
 // Parameters:
 // - luaAction: a pointer to a LuaScriptAction object.
@@ -185,7 +185,7 @@ func (aw *Worker) loadScript(luaAction *LuaScriptAction, scriptPath string) {
 	)
 
 	if scriptCompiled, err = lualib.CompileLua(scriptPath); err != nil {
-		level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+		level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 		return
 	}
@@ -316,7 +316,7 @@ func (aw *Worker) runScript(index int, L *lua.LState, request *lua.LTable, logs 
 			"context", fmt.Sprintf("%+v", aw.luaActionRequest.Context),
 		)
 
-		level.Info(logging.DefaultLogger).Log(
+		level.Info(logging.Logger).Log(
 			append([]any{
 				global.LogKeyGUID, aw.luaActionRequest.Session,
 				"script", aw.actionScripts[index].ScriptPath,
@@ -363,7 +363,7 @@ func (aw *Worker) executeScript(L *lua.LState, index int, request *lua.LTable) e
 // It takes the index of the action script, the error that occurred, and the custom log key-value pair as parameters.
 // It logs the error, script path, session ID, and custom log key-value pair using the error logger.
 func (aw *Worker) logScriptFailure(index int, err error, logs *lualib.CustomLogKeyValue) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		append([]any{
 			global.LogKeyGUID, aw.luaActionRequest.Session,
 			"script", aw.actionScripts[index].ScriptPath,

--- a/server/lualib/callback/callback.go
+++ b/server/lualib/callback/callback.go
@@ -355,7 +355,7 @@ func executeAndHandleError(compiledScript *lua.FunctionProto, logTable *lua.LTab
 //
 //	executeAndHandleError(compiledScript, L)
 func processError(err error) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		"script", config.LoadableConfig.GetLuaCallbackScriptPath(),
 		global.LogKeyError, err,
 	)

--- a/server/lualib/context.go
+++ b/server/lualib/context.go
@@ -73,7 +73,7 @@ func (c *Context) Delete(key lua.LValue) {
 	case lua.LNumber:
 		delete(c.data, float64(mappedKey))
 	default:
-		level.Warn(logging.DefaultLogger).Log(
+		level.Warn(logging.Logger).Log(
 			global.LogKeyWarning, fmt.Sprintf("Lua key '%v' unsupported", mappedKey))
 	}
 
@@ -116,7 +116,7 @@ func ContextSet(ctx *Context) lua.LGFunction {
 		case *lua.LTable:
 			ctx.Set(key, LuaTableToMap(value))
 		default:
-			level.Warn(logging.DefaultLogger).Log(
+			level.Warn(logging.Logger).Log(
 				global.LogKeyWarning, fmt.Sprintf("Lua key='%v' value='%v' unsupported", key, value))
 		}
 
@@ -142,7 +142,7 @@ func ContextGet(ctx *Context) lua.LGFunction {
 		case nil:
 			L.Push(lua.LNil)
 		default:
-			level.Warn(logging.DefaultLogger).Log(
+			level.Warn(logging.Logger).Log(
 				global.LogKeyWarning, fmt.Sprintf("Lua key='%v' value='%v' unsupported", key, value))
 			L.Push(lua.LNil)
 		}

--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -312,7 +312,7 @@ func (r *Request) executeScripts(ctx *gin.Context, L *lua.LState, request *lua.L
 
 // handleError logs the error message and cancels the Lua context.
 func (r *Request) handleError(luaCancel context.CancelFunc, err error, scriptName string, stopTimer func()) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		global.LogKeyGUID, r.Session,
 		"name", scriptName,
 		global.LogKeyError, err,
@@ -334,10 +334,10 @@ func (r *Request) handleError(luaCancel context.CancelFunc, err error, scriptNam
 // Example usage:
 // r.generateLog(triggered, abortFeatures, ret, scriptName)
 //
-// NOTE: This method uses the logging.DefaultErrLogger logger.
+// NOTE: This method uses the logging.Logger logger.
 //
 // Dependencies:
-// - logging.DefaultErrLogger: the default error logger for logging the log entry
+// - logging.Logger: the default error logger for logging the log entry
 // - global.LogKeyGUID: the constant representing the log key for the session ID
 // - global.LogKeyMsg: the constant representing the log key for the log message
 // - r.formatResult: a helper method to format the feature result as a string
@@ -367,7 +367,7 @@ func (r *Request) generateLog(triggered, abortFeatures bool, ret int, scriptName
 		}
 	}
 
-	level.Info(logging.DefaultLogger).Log(logs...)
+	level.Info(logging.Logger).Log(logs...)
 }
 
 // formatResult returns the formatted result based on the given ret value.

--- a/server/lualib/filter/filter.go
+++ b/server/lualib/filter/filter.go
@@ -457,7 +457,7 @@ func executeScriptWithinContext(request *lua.LTable, script *LuaFilter, r *Reque
 // logError is a function that logs error information when a LuaFilter script fails during a Request session.
 // It logs the Session GUID, the name of the script, and the error message to the default error logger with an Error level.
 func logError(r *Request, script *LuaFilter, err error) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		global.LogKeyGUID, r.Session,
 		"name", script.Name,
 		global.LogKeyError, err,
@@ -481,7 +481,7 @@ func logResult(r *Request, script *LuaFilter, action bool, ret int) {
 			}
 		}
 
-		level.Info(logging.DefaultErrLogger).Log(logs...)
+		level.Info(logging.Logger).Log(logs...)
 	}
 
 	util.DebugModule(

--- a/server/monitoring/connection.go
+++ b/server/monitoring/connection.go
@@ -75,7 +75,7 @@ func checkHAproxyV2(conn net.Conn, ipAddress string, port int) error {
 }
 
 func handleHAproxyV2Error(err error) {
-	level.Error(logging.DefaultErrLogger).Log(
+	level.Error(logging.Logger).Log(
 		global.LogKeyInstance, global.InstanceName,
 		global.LogKeyError, "HAProxy v2 error", "error", err,
 	)

--- a/server/rediscli/cient.go
+++ b/server/rediscli/cient.go
@@ -23,7 +23,7 @@ func redisTLSOptions(tlsCfg *config.TLS) *tls.Config {
 	if config.LoadableConfig.Server.Redis.TLS.Enabled {
 		cert, err := tls.LoadX509KeyPair(tlsCfg.Cert, tlsCfg.Key)
 		if err != nil {
-			level.Error(logging.DefaultErrLogger).Log(global.LogKeyInstance, config.LoadableConfig.Server.InstanceName, global.LogKeyError, err)
+			level.Error(logging.Logger).Log(global.LogKeyInstance, config.LoadableConfig.Server.InstanceName, global.LogKeyError, err)
 
 			return nil
 		}
@@ -148,13 +148,13 @@ func NewRedisReplicaClient() redis.UniversalClient {
 // NewDNSResolver creates a new DNS resolver based on the configured settings.
 func NewDNSResolver() (resolver *net.Resolver) {
 	if config.LoadableConfig.Server.DNS.Resolver == "" {
-		level.Debug(logging.DefaultLogger).Log(global.LogKeyMsg, "Using default DNS resolver")
+		level.Debug(logging.Logger).Log(global.LogKeyMsg, "Using default DNS resolver")
 
 		resolver = &net.Resolver{
 			PreferGo: true,
 		}
 	} else {
-		level.Debug(logging.DefaultLogger).Log(global.LogKeyMsg, fmt.Sprintf("Using DNS resolver %s", config.LoadableConfig.Server.DNS.Resolver))
+		level.Debug(logging.Logger).Log(global.LogKeyMsg, fmt.Sprintf("Using DNS resolver %s", config.LoadableConfig.Server.DNS.Resolver))
 
 		resolver = &net.Resolver{
 			PreferGo: true,

--- a/server/stats/statistics.go
+++ b/server/stats/statistics.go
@@ -162,7 +162,7 @@ func MeasureCPU(ctx context.Context) {
 
 			newCpu, err := cpu.Get()
 			if err != nil {
-				level.Error(logging.DefaultErrLogger).Log(global.LogKeyError, err)
+				level.Error(logging.Logger).Log(global.LogKeyError, err)
 
 				return
 			}
@@ -194,15 +194,15 @@ func MeasureCPU(ctx context.Context) {
 //
 // It uses the util.ByteSize function to convert the memory values in bytes to kilobytes (KB)
 // by dividing them by 1024.
-// The logging is performed using the DefaultLogger from the logging package.
-// Note: The declarations of logging.DefaultLogger, global.LogKeyStatsAlloc, util.ByteSize,
+// The logging is performed using the Logger from the logging package.
+// Note: The declarations of logging.Logger, global.LogKeyStatsAlloc, util.ByteSize,
 // and other related declarations are not shown here.
 func PrintStats() {
 	var memStats runtime.MemStats
 
 	runtime.ReadMemStats(&memStats)
 
-	level.Info(logging.DefaultLogger).Log(
+	level.Info(logging.Logger).Log(
 		// Heap Stats
 		global.LogKeyStatsHeapAlloc, util.ByteSize(memStats.HeapAlloc),
 		global.LogKeyStatsHeapInUse, util.ByteSize(memStats.HeapInuse),

--- a/server/util/util.go
+++ b/server/util/util.go
@@ -36,7 +36,7 @@ type RedisLogger struct{}
 
 // Printf implements the printf function from Redis.
 func (r *RedisLogger) Printf(_ context.Context, format string, values ...any) {
-	level.Info(logging.DefaultLogger).Log("redis", fmt.Sprintf(format, values...))
+	level.Info(logging.Logger).Log("redis", fmt.Sprintf(format, values...))
 }
 
 // CryptPassword is a container for an encrypted password typically used in SQL fields.
@@ -267,7 +267,7 @@ func DebugModule(module global.DbgModule, keyvals ...any) {
 			keyvals = append(keyvals, "function")
 			keyvals = append(keyvals, runtime.FuncForPC(counter).Name())
 
-			level.Debug(logging.DefaultLogger).Log(keyvals...)
+			level.Debug(logging.Logger).Log(keyvals...)
 		}
 
 		break

--- a/vendor/github.com/go-kit/log/term/LICENSE
+++ b/vendor/github.com/go-kit/log/term/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Simon Eskildsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/go-kit/log/term/colorlogger.go
+++ b/vendor/github.com/go-kit/log/term/colorlogger.go
@@ -1,0 +1,144 @@
+package term
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/go-kit/log"
+)
+
+// Color represents an ANSI color. The zero value is Default.
+type Color uint8
+
+// ANSI colors.
+const (
+	Default = Color(iota)
+
+	Black
+	DarkRed
+	DarkGreen
+	Brown
+	DarkBlue
+	DarkMagenta
+	DarkCyan
+	Gray
+
+	DarkGray
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	White
+
+	numColors
+)
+
+// For more on ANSI escape codes see
+// https://en.wikipedia.org/wiki/ANSI_escape_code. See in particular
+// https://en.wikipedia.org/wiki/ANSI_escape_code#Colors.
+
+var (
+	resetColorBytes = []byte("\x1b[39;49;22m")
+	fgColorBytes    [][]byte
+	bgColorBytes    [][]byte
+)
+
+func init() {
+	// Default
+	fgColorBytes = append(fgColorBytes, []byte("\x1b[39m"))
+	bgColorBytes = append(bgColorBytes, []byte("\x1b[49m"))
+
+	// dark colors
+	for color := Black; color < DarkGray; color++ {
+		fgColorBytes = append(fgColorBytes, []byte(fmt.Sprintf("\x1b[%dm", 30+color-Black)))
+		bgColorBytes = append(bgColorBytes, []byte(fmt.Sprintf("\x1b[%dm", 40+color-Black)))
+	}
+
+	// bright colors
+	for color := DarkGray; color < numColors; color++ {
+		fgColorBytes = append(fgColorBytes, []byte(fmt.Sprintf("\x1b[%d;1m", 30+color-DarkGray)))
+		bgColorBytes = append(bgColorBytes, []byte(fmt.Sprintf("\x1b[%d;1m", 40+color-DarkGray)))
+	}
+}
+
+// FgBgColor represents a foreground and background color.
+type FgBgColor struct {
+	Fg, Bg Color
+}
+
+func (c FgBgColor) isZero() bool {
+	return c.Fg == Default && c.Bg == Default
+}
+
+// NewColorLogger returns a Logger which writes colored logs to w. ANSI color
+// codes for the colors returned by color are added to the formatted output
+// from the Logger returned by newLogger and the combined result written to w.
+func NewColorLogger(w io.Writer, newLogger func(io.Writer) log.Logger, color func(keyvals ...interface{}) FgBgColor) log.Logger {
+	if color == nil {
+		panic("color func nil")
+	}
+	return &colorLogger{
+		w:             w,
+		newLogger:     newLogger,
+		color:         color,
+		bufPool:       sync.Pool{New: func() interface{} { return &loggerBuf{} }},
+		noColorLogger: newLogger(w),
+	}
+}
+
+type colorLogger struct {
+	w             io.Writer
+	newLogger     func(io.Writer) log.Logger
+	color         func(keyvals ...interface{}) FgBgColor
+	bufPool       sync.Pool
+	noColorLogger log.Logger
+}
+
+func (l *colorLogger) Log(keyvals ...interface{}) error {
+	color := l.color(keyvals...)
+	if color.isZero() {
+		return l.noColorLogger.Log(keyvals...)
+	}
+
+	lb := l.getLoggerBuf()
+	defer l.putLoggerBuf(lb)
+	if color.Fg != Default {
+		lb.buf.Write(fgColorBytes[color.Fg])
+	}
+	if color.Bg != Default {
+		lb.buf.Write(bgColorBytes[color.Bg])
+	}
+	err := lb.logger.Log(keyvals...)
+	if err != nil {
+		return err
+	}
+	if color.Fg != Default || color.Bg != Default {
+		lb.buf.Write(resetColorBytes)
+	}
+	_, err = io.Copy(l.w, lb.buf)
+	return err
+}
+
+type loggerBuf struct {
+	buf    *bytes.Buffer
+	logger log.Logger
+}
+
+func (l *colorLogger) getLoggerBuf() *loggerBuf {
+	lb := l.bufPool.Get().(*loggerBuf)
+	if lb.buf == nil {
+		lb.buf = &bytes.Buffer{}
+		lb.logger = l.newLogger(lb.buf)
+	} else {
+		lb.buf.Reset()
+	}
+	return lb
+}
+
+func (l *colorLogger) putLoggerBuf(cb *loggerBuf) {
+	l.bufPool.Put(cb)
+}

--- a/vendor/github.com/go-kit/log/term/colorwriter_others.go
+++ b/vendor/github.com/go-kit/log/term/colorwriter_others.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package term
+
+import "io"
+
+// NewColorWriter returns an io.Writer that writes to w and provides cross
+// platform support for ANSI color codes. If w is not a terminal it is
+// returned unmodified.
+func NewColorWriter(w io.Writer) io.Writer {
+	return w
+}

--- a/vendor/github.com/go-kit/log/term/colorwriter_windows.go
+++ b/vendor/github.com/go-kit/log/term/colorwriter_windows.go
@@ -1,0 +1,188 @@
+// The code in this file is adapted from github.com/mattn/go-colorable.
+
+package term
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+type colorWriter struct {
+	out     io.Writer
+	handle  syscall.Handle
+	lastbuf bytes.Buffer
+	oldattr word
+}
+
+// NewColorWriter returns an io.Writer that writes to w and provides cross
+// platform support for ANSI color codes. If w is not a terminal it is
+// returned unmodified.
+func NewColorWriter(w io.Writer) io.Writer {
+	if !IsConsole(w) {
+		return w
+	}
+
+	var csbi consoleScreenBufferInfo
+	handle := syscall.Handle(w.(fder).Fd())
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+
+	return &colorWriter{
+		out:     w,
+		handle:  handle,
+		oldattr: csbi.attributes,
+	}
+}
+
+func (w *colorWriter) Write(data []byte) (n int, err error) {
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
+
+	er := bytes.NewBuffer(data)
+loop:
+	for {
+		r1, _, _ := procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
+		if r1 == 0 {
+			break loop
+		}
+
+		c1, _, err := er.ReadRune()
+		if err != nil {
+			break loop
+		}
+		if c1 != 0x1b {
+			fmt.Fprint(w.out, string(c1))
+			continue
+		}
+		c2, _, err := er.ReadRune()
+		if err != nil {
+			w.lastbuf.WriteRune(c1)
+			break loop
+		}
+		if c2 != 0x5b {
+			w.lastbuf.WriteRune(c1)
+			w.lastbuf.WriteRune(c2)
+			continue
+		}
+
+		var buf bytes.Buffer
+		var m rune
+		for {
+			c, _, err := er.ReadRune()
+			if err != nil {
+				w.lastbuf.WriteRune(c1)
+				w.lastbuf.WriteRune(c2)
+				w.lastbuf.Write(buf.Bytes())
+				break loop
+			}
+			if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '@' {
+				m = c
+				break
+			}
+			buf.Write([]byte(string(c)))
+		}
+
+		switch m {
+		case 'm':
+			attr := csbi.attributes
+			cs := buf.String()
+			if cs == "" {
+				procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(w.oldattr))
+				continue
+			}
+			token := strings.Split(cs, ";")
+			intensityMode := word(0)
+			for _, ns := range token {
+				if n, err = strconv.Atoi(ns); err == nil {
+					switch {
+					case n == 0:
+						attr = w.oldattr
+					case n == 1:
+						attr |= intensityMode
+					case 30 <= n && n <= 37:
+						attr = (attr & backgroundMask)
+						if (n-30)&1 != 0 {
+							attr |= foregroundRed
+						}
+						if (n-30)&2 != 0 {
+							attr |= foregroundGreen
+						}
+						if (n-30)&4 != 0 {
+							attr |= foregroundBlue
+						}
+						intensityMode = foregroundIntensity
+					case n == 39: // reset foreground color
+						attr &= backgroundMask
+						attr |= w.oldattr & foregroundMask
+					case 40 <= n && n <= 47:
+						attr = (attr & foregroundMask)
+						if (n-40)&1 != 0 {
+							attr |= backgroundRed
+						}
+						if (n-40)&2 != 0 {
+							attr |= backgroundGreen
+						}
+						if (n-40)&4 != 0 {
+							attr |= backgroundBlue
+						}
+						intensityMode = backgroundIntensity
+					case n == 49: // reset background color
+						attr &= foregroundMask
+						attr |= w.oldattr & backgroundMask
+					}
+					procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(attr))
+				}
+			}
+		}
+	}
+	return len(data) - w.lastbuf.Len(), nil
+}
+
+var (
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+	procSetConsoleTextAttribute    = kernel32.NewProc("SetConsoleTextAttribute")
+)
+
+const (
+	foregroundBlue      = 0x1
+	foregroundGreen     = 0x2
+	foregroundRed       = 0x4
+	foregroundIntensity = 0x8
+	foregroundMask      = (foregroundRed | foregroundBlue | foregroundGreen | foregroundIntensity)
+	backgroundBlue      = 0x10
+	backgroundGreen     = 0x20
+	backgroundRed       = 0x40
+	backgroundIntensity = 0x80
+	backgroundMask      = (backgroundRed | backgroundBlue | backgroundGreen | backgroundIntensity)
+)
+
+type (
+	wchar uint16 //lint:ignore U1000 unused
+	short int16  //lint:ignore U1000 unused
+	dword uint32 //lint:ignore U1000 unused
+	word  uint16 //lint:ignore U1000 unused
+)
+
+type coord struct {
+	x short //lint:ignore U1000 unused
+	y short //lint:ignore U1000 unused
+}
+
+type smallRect struct {
+	left   short //lint:ignore U1000 unused
+	top    short //lint:ignore U1000 unused
+	right  short //lint:ignore U1000 unused
+	bottom short //lint:ignore U1000 unused
+}
+
+type consoleScreenBufferInfo struct {
+	size              coord
+	cursorPosition    coord
+	attributes        word
+	window            smallRect
+	maximumWindowSize coord
+}

--- a/vendor/github.com/go-kit/log/term/term.go
+++ b/vendor/github.com/go-kit/log/term/term.go
@@ -1,0 +1,22 @@
+// Package term provides tools for logging to a terminal.
+package term
+
+import (
+	"io"
+
+	"github.com/go-kit/log"
+)
+
+// NewLogger returns a Logger that takes advantage of terminal features if
+// possible. Log events are formatted by the Logger returned by newLogger. If
+// w is a terminal each log event is colored according to the color function.
+func NewLogger(w io.Writer, newLogger func(io.Writer) log.Logger, color func(keyvals ...interface{}) FgBgColor) log.Logger {
+	if !IsTerminal(w) {
+		return newLogger(w)
+	}
+	return NewColorLogger(NewColorWriter(w), newLogger, color)
+}
+
+type fder interface {
+	Fd() uintptr
+}

--- a/vendor/github.com/go-kit/log/term/terminal_darwin.go
+++ b/vendor/github.com/go-kit/log/term/terminal_darwin.go
@@ -1,0 +1,10 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package term
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA

--- a/vendor/github.com/go-kit/log/term/terminal_freebsd.go
+++ b/vendor/github.com/go-kit/log/term/terminal_freebsd.go
@@ -1,0 +1,7 @@
+package term
+
+import (
+	"syscall"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA

--- a/vendor/github.com/go-kit/log/term/terminal_linux.go
+++ b/vendor/github.com/go-kit/log/term/terminal_linux.go
@@ -1,0 +1,13 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !appengine
+// +build !appengine
+
+package term
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TCGETS

--- a/vendor/github.com/go-kit/log/term/terminal_notwindows.go
+++ b/vendor/github.com/go-kit/log/term/terminal_notwindows.go
@@ -1,0 +1,26 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build (linux && !appengine) || darwin || freebsd || openbsd
+// +build linux,!appengine darwin freebsd openbsd
+
+package term
+
+import (
+	"io"
+	"syscall"
+	"unsafe"
+)
+
+// IsTerminal returns true if w writes to a terminal.
+func IsTerminal(w io.Writer) bool {
+	fw, ok := w.(fder)
+	if !ok {
+		return false
+	}
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fw.Fd(), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/go-kit/log/term/terminal_openbsd.go
+++ b/vendor/github.com/go-kit/log/term/terminal_openbsd.go
@@ -1,0 +1,5 @@
+package term
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA

--- a/vendor/github.com/go-kit/log/term/terminal_stub.go
+++ b/vendor/github.com/go-kit/log/term/terminal_stub.go
@@ -1,0 +1,16 @@
+// Based on ssh/terminal:
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build appengine || js
+// +build appengine js
+
+package term
+
+import "io"
+
+// IsTerminal always returns false on AppEngine.
+func IsTerminal(w io.Writer) bool {
+	return false
+}

--- a/vendor/github.com/go-kit/log/term/terminal_windows.go
+++ b/vendor/github.com/go-kit/log/term/terminal_windows.go
@@ -1,0 +1,103 @@
+// Based on ssh/terminal:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build windows
+// +build windows
+
+package term
+
+import (
+	"encoding/binary"
+	"io"
+	"regexp"
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetFileInformationByHandleEx = kernel32.NewProc("GetFileInformationByHandleEx")
+	msysPipeNameRegex                = regexp.MustCompile(`\\(cygwin|msys)-\w+-pty\d?-(to|from)-master`)
+)
+
+const (
+	fileNameInfo = 0x02
+)
+
+// IsTerminal returns true if w writes to a terminal.
+func IsTerminal(w io.Writer) bool {
+	return IsConsole(w) || IsMSYSTerminal(w)
+}
+
+// IsConsole returns true if w writes to a Windows console.
+func IsConsole(w io.Writer) bool {
+	var handle syscall.Handle
+
+	if fw, ok := w.(fder); ok {
+		handle = syscall.Handle(fw.Fd())
+	} else {
+		// The writer has no file-descriptor and so can't be a terminal.
+		return false
+	}
+
+	var st uint32
+	err := syscall.GetConsoleMode(handle, &st)
+
+	// If the handle is attached to a terminal, GetConsoleMode returns a
+	// non-zero value containing the console mode flags. We don't care about
+	// the specifics of flags, just that it is not zero.
+	return (err == nil && st != 0)
+}
+
+// IsMSYSTerminal returns true if w writes to a MSYS/MSYS2 terminal.
+func IsMSYSTerminal(w io.Writer) bool {
+	var handle syscall.Handle
+
+	if fw, ok := w.(fder); ok {
+		handle = syscall.Handle(fw.Fd())
+	} else {
+		// The writer has no file-descriptor and so can't be a terminal.
+		return false
+	}
+
+	// MSYS(2) terminal reports as a pipe for STDIN/STDOUT/STDERR. If it isn't
+	// a pipe, it can't be a MSYS(2) terminal.
+	filetype, err := syscall.GetFileType(handle)
+
+	if filetype != syscall.FILE_TYPE_PIPE || err != nil {
+		return false
+	}
+
+	// MSYS2/Cygwin terminal's name looks like: \msys-dd50a72ab4668b33-pty2-to-master
+	data := make([]byte, 256)
+
+	r, _, e := syscall.Syscall6(
+		procGetFileInformationByHandleEx.Addr(),
+		4,
+		uintptr(handle),
+		uintptr(fileNameInfo),
+		uintptr(unsafe.Pointer(&data[0])),
+		uintptr(len(data)),
+		0,
+		0,
+	)
+
+	if r != 0 && e == 0 {
+		// The first 4 bytes of the buffer are the size of the UTF16 name, in bytes.
+		unameLen := binary.LittleEndian.Uint32(data[:4]) / 2
+		uname := make([]uint16, unameLen)
+
+		for i := uint32(0); i < unameLen; i++ {
+			uname[i] = binary.LittleEndian.Uint16(data[i*2+4 : i*2+2+4])
+		}
+
+		name := syscall.UTF16ToString(uname)
+
+		return msysPipeNameRegex.MatchString(name)
+	}
+
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,6 +187,7 @@ github.com/go-jose/go-jose/v4/json
 ## explicit; go 1.17
 github.com/go-kit/log
 github.com/go-kit/log/level
+github.com/go-kit/log/term
 # github.com/go-ldap/ldap/v3 v3.4.8
 ## explicit; go 1.14
 github.com/go-ldap/ldap/v3


### PR DESCRIPTION
Updated the logging calls throughout the codebase to use `logging.Logger` instead of `logging.DefaultLogger` or `logging.DefaultErrLogger`. This change unifies the logger usage and improves consistency in logging across various modules.