### PR TITLE
Set result flags in context for various plugins

### DIFF
--- a/server/lua-plugins.d/actions/bruteforce.lua
+++ b/server/lua-plugins.d/actions/bruteforce.lua
@@ -16,6 +16,17 @@ function nauthilus_call_action(request)
         end
 
         nauthilus_util.if_error_raise(err)
+
+        -- Get result table
+        local rt = nauthilus.context_get("rt")
+        if rt == nil then
+            rt = {}
+        end
+        if nauthilus_util.is_table(rt) then
+            rt.brute_force_haproxy = true
+
+            nauthilus.context_set("rt", rt)
+        end
     end
 
     -- Required by telegram.lua

--- a/server/lua-plugins.d/actions/haveibeenpwnd.lua
+++ b/server/lua-plugins.d/actions/haveibeenpwnd.lua
@@ -59,7 +59,7 @@ function nauthilus_call_action(request)
         nauthilus_util.if_error_raise(err)
 
         if result.code ~= 200 then
-            error("haveibeenpwnd did not return status code 200")
+            nauthilus_util.if_error_raise("haveibeenpwnd did not return status code 200")
         end
 
         for line in result.body:gmatch("([^\n]*)\n?") do
@@ -116,6 +116,17 @@ function nauthilus_call_action(request)
 
                     nauthilus.redis_hset(redis_key, "send_mail", 1)
                     nauthilus.redis_expire(redis_key, 86400)
+
+                    -- Get result table
+                    local rt = nauthilus.context_get("rt")
+                    if rt == nil then
+                        rt = {}
+                    end
+                    if nauthilus_util.is_table(rt) then
+                        rt.action_haveibeenpwnd = true
+
+                        nauthilus.context_set("rt", rt)
+                    end
                 end
 
                 return nauthilus.ACTION_RESULT_OK

--- a/server/lua-plugins.d/actions/telegram.lua
+++ b/server/lua-plugins.d/actions/telegram.lua
@@ -29,19 +29,6 @@ function nauthilus_call_action(request)
     end
 
     if nauthilus_util.is_table(rt) and nauthilus_util.table_length(rt) > 0 then
-        if request.debug then
-            rt.caller = "telegram.lua"
-
-            local rt_json, err = json.encode(rt)
-            nauthilus_util.if_error_raise(err)
-
-            if request.debug then
-                print(rt_json)
-            end
-
-            rt.caller = nil
-        end
-
         -- brute_force_haproxy
         if rt.brute_force_haproxy then
             send_message = true
@@ -52,7 +39,7 @@ function nauthilus_call_action(request)
         -- feature_haproxy (not part of demo plugins)
         if rt.feature_haproxy then
             send_message = true
-            if request.feature ~= nil and request.feature ~= "" then
+            if request.feature and request.feature ~= "" then
                 headline = "Feature " .. request.feature .. " triggered"
                 log_prefix = request.feature .. "_"
             else

--- a/server/lua-plugins.d/filters/geoip.lua
+++ b/server/lua-plugins.d/filters/geoip.lua
@@ -99,6 +99,17 @@ function nauthilus_call_filter(request)
                 nauthilus.context_set(N, "ok")
                 nauthilus.custom_log_add(N, "blocked")
 
+                -- Get result table
+                local rt = nauthilus.context_get("rt")
+                if rt == nil then
+                    rt = {}
+                end
+                if nauthilus_util.is_table(rt) then
+                    rt.filter_geoippolicyd = true
+
+                    nauthilus.context_set("rt", rt)
+                end
+
                 return nauthilus.FILTER_REJECT, nauthilus.FILTER_RESULT_OK
             end
         else


### PR DESCRIPTION
Added logic to set specific flags in the result table (`rt`) within geoip, bruteforce, and haveibeenpwnd plugins. Simplified debug logic in the telegram plugin and adjusted error handling for haveibeenpwnd.