### PR TITLE
Refactor to use nauthilus_redis module

### DIFF
--- a/server/lua-plugins.d/callback/callback.lua
+++ b/server/lua-plugins.d/callback/callback.lua
@@ -1,4 +1,5 @@
 local nauthilus_util = require("nauthilus_util")
+local nauthilus_redis = require("nauthilus_redis")
 
 local crypto = require("crypto")
 local json = require("json")
@@ -109,11 +110,11 @@ function nauthilus_run_callback(logging)
                 result.cmd = "NOOP"
                 result.state = "client session refreshed"
 
-                local _, err_redis_expire = nauthilus_builtin.redis_expire(redis_key, 3600)
+                local _, err_redis_expire = nauthilus_redis.redis_expire(redis_key, 3600)
                 nauthilus_util.if_error_raise(err_redis_expire)
             else
                 -- Cleanup dovecot session
-                local deleted, err_redis_hdel = nauthilus_builtin.redis_hdel(redis_key, result.dovecot_session)
+                local deleted, err_redis_hdel = nauthilus_redis.redis_hdel(redis_key, result.dovecot_session)
                 if err_redis_hdel then
                     result.remove_dovecot_session_status = err_redis_hdel
                 else


### PR DESCRIPTION
Replaced nauthilus_builtin functions with nauthilus_redis equivalents. This ensures consistent use of the nauthilus_redis module for Redis operations, enhancing code maintainability and clarity.