### PR TITLE
Fix: Ensure Lua stack is clean before running scripts.

### DIFF
--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -284,6 +284,10 @@ func (aw *Worker) handleRequest(httpRequest *http.Request) {
 
 	for index := range aw.actionScripts {
 		if aw.actionScripts[index].LuaAction == aw.luaActionRequest.LuaAction && !errors.Is((aw.ctx).Err(), context.Canceled) {
+			if L.GetTop() != 0 {
+				L.SetTop(0)
+			}
+
 			aw.runScript(index, L, request, logs)
 		}
 	}

--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -273,6 +273,10 @@ func (r *Request) setRequest(L *lua.LState) *lua.LTable {
 // err error: an error that might have occurred during the execution of the scripts.
 func (r *Request) executeScripts(ctx *gin.Context, L *lua.LState, request *lua.LTable) (triggered bool, abortFeatures bool, err error) {
 	for index := range LuaFeatures.LuaScripts {
+		if L.GetTop() != 0 {
+			L.SetTop(0)
+		}
+
 		stopTimer := stats.PrometheusTimer(global.PromFeature, LuaFeatures.LuaScripts[index].Name)
 
 		if stderrors.Is(ctx.Err(), context.Canceled) {

--- a/server/lualib/filter/filter.go
+++ b/server/lualib/filter/filter.go
@@ -614,6 +614,10 @@ func (r *Request) CallFilterLua(ctx *gin.Context) (action bool, backendResult *l
 	mergedRemoveAttributes := config.NewStringSet()
 
 	for _, script := range LuaFilters.LuaScripts {
+		if L.GetTop() != 0 {
+			L.SetTop(0)
+		}
+
 		if stderrors.Is(ctx.Err(), context.Canceled) {
 			return
 		}


### PR DESCRIPTION
Add checks to reset the Lua stack to zero before executing scripts in action, filter, and feature modules. This prevents potential stack-related errors and ensures consistency across script executions.