### PR TITLE
Fix: Refactor log message strings to global constants

### DIFF
--- a/server/core/features.go
+++ b/server/core/features.go
@@ -149,14 +149,14 @@ func (a *AuthState) featureTLSEncryption() (triggered bool) {
 	defer stopTimer()
 
 	if a.isInNetwork(config.LoadableConfig.ClearTextList) {
-		logMessage("Client has no transport security", *a.GUID, global.FeatureTLSEncryption, a.ClientIP)
+		logMessage(global.NoTLS, *a.GUID, global.FeatureTLSEncryption, a.ClientIP)
 
 		triggered = true
 
 		return
 	}
 
-	logMessage("Client is whitelisted", *a.GUID, global.FeatureTLSEncryption, a.ClientIP)
+	logMessage(global.Whitelisted, *a.GUID, global.FeatureTLSEncryption, a.ClientIP)
 
 	return
 }
@@ -351,11 +351,9 @@ func (a *AuthState) featureRBLs(ctx *gin.Context) (triggered bool, err error) {
 	defer stopTimer()
 
 	if a.isInNetwork(config.LoadableConfig.RBLs.IPWhiteList) {
-		level.Info(log.Logger).Log(
-			global.LogKeyGUID, a.GUID, global.FeatureRBL, "Client is whitelisted", global.LogKeyClientIP, a.ClientIP,
-		)
+		logMessage(global.Whitelisted, *a.GUID, global.FeatureRBL, a.ClientIP)
 
-		//return
+		return
 	}
 
 	totalRBLScore, err = a.checkRBLs(ctx)

--- a/server/global/const.go
+++ b/server/global/const.go
@@ -1502,5 +1502,13 @@ const (
 	PromDNS = "dns"
 )
 
-// DNSResolvePTR is a constant string representing the value "resolve". It is used in the context of DNS resolution.
-const DNSResolvePTR = "ptr"
+const (
+	// DNSResolvePTR is a constant string representing the value "resolve". It is used in the context of DNS resolution.
+	DNSResolvePTR = "ptr"
+
+	// Whitelisted is a constant string representing the status of a client being whitelisted.
+	Whitelisted = "Client is whitelisted"
+
+	// NoTLS represents a constant string indicating that the client does not have transport security.
+	NoTLS = "Client has no transport security"
+)


### PR DESCRIPTION
Replaced hardcoded log message strings with predefined global constants for better consistency and maintainability. This change aims to centralize message strings, making future updates easier and reducing potential errors from string literals.