### PR TITLE
Fix: Refactor logging in filter and feature modules

### DIFF
--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -29,6 +29,7 @@ import (
 	"github.com/croessner/nauthilus/server/log"
 	"github.com/croessner/nauthilus/server/lualib"
 	"github.com/croessner/nauthilus/server/stats"
+	"github.com/croessner/nauthilus/server/util"
 	"github.com/gin-gonic/gin"
 	"github.com/go-kit/log/level"
 	"github.com/spf13/viper"
@@ -404,7 +405,7 @@ func (r *Request) generateLog(triggered, abortFeatures bool, ret int, scriptName
 		}
 	}
 
-	level.Info(log.Logger).Log(logs...)
+	util.DebugModule(global.DbgFeature, logs...)
 }
 
 // formatResult returns the formatted result based on the given ret value.

--- a/server/lualib/filter/filter.go
+++ b/server/lualib/filter/filter.go
@@ -536,29 +536,24 @@ func logError(r *Request, script *LuaFilter, err error) {
 func logResult(r *Request, script *LuaFilter, action bool, ret int) {
 	resultMap := map[int]string{global.ResultOk: "ok", global.ResultFail: "fail"}
 
+	logs := []any{
+		global.LogKeyGUID, r.Session,
+		"name", script.Name,
+		global.LogKeyMsg, "Lua filter finished",
+		"action", action,
+		"result", resultMap[ret],
+	}
+
 	if ret != 0 {
-		logs := []any{
-			global.LogKeyGUID, r.Session,
-			"name", script.Name,
-		}
 
 		if r.Logs != nil {
 			for index := range *r.Logs {
 				logs = append(logs, (*r.Logs)[index])
 			}
 		}
-
-		level.Info(log.Logger).Log(logs...)
 	}
 
-	util.DebugModule(
-		global.DbgFilter,
-		global.LogKeyGUID, r.Session,
-		"name", script.Name,
-		global.LogKeyMsg, "Lua filter finished",
-		"action", action,
-		"result", resultMap[ret],
-	)
+	util.DebugModule(global.DbgFilter, logs...)
 }
 
 // mergeMaps merges 2 maps into one. If same key exists in both maps, value from m2 is used.


### PR DESCRIPTION
Reorganize the log assembly in the filter module for clarity and ensured the util.DebugModule method is used consistently across both filter and feature modules for debugging logs. This change enhances code readability and aligns logging behavior between different parts of the system.