### PR TITLE
Disable Docker build and push stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,60 +95,60 @@ release:
   rules:
     - if: $CI_COMMIT_TAG
 
-docker:
-  stage: build
-  image: docker:26
-  before_script:
-    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" ${CI_REGISTRY}
-  script:
-    - docker pull ${CI_REGISTRY_IMAGE}:latest || true
-    - >
-      docker build
-      --pull
-      --build-arg http_proxy=${http_proxy}
-      --build-arg https_proxy=${https_proxy}
-      --build-arg no_proxy=${no_proxy}
-      --cache-from ${CI_REGISTRY_IMAGE}:latest
-      --label "org.opencontainers.image.title=${CI_PROJECT_TITLE}"
-      --label "org.opencontainers.image.url=${CI_PROJECT_URL}"
-      --label "org.opencontainers.image.created=${CI_JOB_STARTED_AT}"
-      --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
-      --label "org.opencontainers.image.version=${CI_COMMIT_REF_NAME}"
-      --tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
-      .
-    - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
-
-push tags 1/2:
-  stage: push
-  image: docker:26
-  before_script:
-    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" ${CI_REGISTRY}
-  variables:
-    GIT_STRATEGY: none
-  script:
-    - docker pull ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
-    - |
-      if [[ "${CI_COMMIT_BRANCH}" == "${CI_DEFAULT_BRANCH}" ]]; then
-        docker_tag="latest"
-      else
-        docker_tag="dev"
-      fi
-    - docker tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${docker_tag}
-    - docker push ${CI_REGISTRY_IMAGE}:${docker_tag}
-
-push tags 2/2:
-  stage: push
-  image: docker:26
-  before_script:
-    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" ${CI_REGISTRY}
-  variables:
-    GIT_STRATEGY: none
-  script:
-    - docker pull ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
-    - docker tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}
-    - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}
-  rules:
-    - if: $CI_COMMIT_TAG
+# docker:
+#   stage: build
+#   image: docker:26
+#   before_script:
+#     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" ${CI_REGISTRY}
+#   script:
+#     - docker pull ${CI_REGISTRY_IMAGE}:latest || true
+#     - >
+#       docker build
+#       --pull
+#       --build-arg http_proxy=${http_proxy}
+#       --build-arg https_proxy=${https_proxy}
+#       --build-arg no_proxy=${no_proxy}
+#       --cache-from ${CI_REGISTRY_IMAGE}:latest
+#       --label "org.opencontainers.image.title=${CI_PROJECT_TITLE}"
+#       --label "org.opencontainers.image.url=${CI_PROJECT_URL}"
+#       --label "org.opencontainers.image.created=${CI_JOB_STARTED_AT}"
+#       --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
+#       --label "org.opencontainers.image.version=${CI_COMMIT_REF_NAME}"
+#       --tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
+#       .
+#     - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
+#
+# push tags 1/2:
+#   stage: push
+#   image: docker:26
+#   before_script:
+#     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" ${CI_REGISTRY}
+#   variables:
+#     GIT_STRATEGY: none
+#   script:
+#     - docker pull ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
+#     - |
+#       if [[ "${CI_COMMIT_BRANCH}" == "${CI_DEFAULT_BRANCH}" ]]; then
+#         docker_tag="latest"
+#       else
+#         docker_tag="dev"
+#       fi
+#     - docker tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${docker_tag}
+#     - docker push ${CI_REGISTRY_IMAGE}:${docker_tag}
+#
+# push tags 2/2:
+#   stage: push
+#   image: docker:26
+#   before_script:
+#     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" ${CI_REGISTRY}
+#   variables:
+#     GIT_STRATEGY: none
+#   script:
+#     - docker pull ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
+#     - docker tag ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}
+#     - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}
+#   rules:
+#     - if: $CI_COMMIT_TAG
 
 secret_detection:
   variables:


### PR DESCRIPTION
Commented out all configurations related to Docker build and push stages in `.gitlab-ci.yml`. This change effectively disables Docker build and tag/push operations in the CI pipeline.