### PR TITLE
Fix: Remove commented-out logo image code

### DIFF
--- a/static/logout.html
+++ b/static/logout.html
@@ -26,8 +26,6 @@
                 <h1 class="center">{{ .Welcome }}</h1>
                 {{ end }}
 
-                <!-- <img src="{{ .LogoImage }}" class="logo" alt="{{ .LogoImageAlt }}"/> -->
-
                 <div class="infobox-container notify center">
                     <span>{{ .LogoutMessage }}</span>
                 </div>


### PR DESCRIPTION
The commented-out code for the logo image in logout.html was removed to clean up the HTML file. This helps to maintain a clearer and more maintainable codebase.