### PR TITLE
Fix: Fix client IP extraction from forwarded addresses

### DIFF
--- a/server/util/util.go
+++ b/server/util/util.go
@@ -453,7 +453,7 @@ func ProcessXForwardedFor(ctx *gin.Context, clientIP, clientPort *string) {
 
 		multipleIPs := strings.Split(fwdAddress, ",")
 		if len(multipleIPs) > 1 {
-			*clientIP = strings.TrimSpace(multipleIPs[len(multipleIPs)-1])
+			*clientIP = strings.TrimSpace(multipleIPs[0])
 		}
 
 		*clientPort = global.NotAvailable


### PR DESCRIPTION
Reverse the logic to ensure the first IP from the 'X-Forwarded-For' header is used, rather than the last. This restores the intended behavior and improves the accuracy of client IP detection.