### PR TITLE
Feat: Add AccountField to various auth structs and Lua requests

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1130,6 +1130,7 @@ func (a *AuthState) handleFeatures(ctx *gin.Context) (authResult global.AuthResu
 				UserAgent:           *a.UserAgent,
 				Username:            a.Username,
 				Account:             "", // unavailable
+				AccountField:        "", // unavailable
 				UniqueUserID:        "", // unavailable
 				DisplayName:         "", // unavailable
 				Password:            a.Password,
@@ -1219,6 +1220,16 @@ func (a *AuthState) handleFeatures(ctx *gin.Context) (authResult global.AuthResu
 	return global.AuthResultOK
 }
 
+// getAccountField returns the value of the AccountField field in the AuthState struct.
+// If the AccountField field is nil, it returns an empty string.
+func (a *AuthState) getAccountField() string {
+	if a.AccountField == nil {
+		return ""
+	}
+
+	return *a.AccountField
+}
+
 // postLuaAction sends a Lua action to be executed asynchronously.
 func (a *AuthState) postLuaAction(passDBResult *PassDBResult) {
 	if !config.LoadableConfig.HaveLuaActions() {
@@ -1262,6 +1273,7 @@ func (a *AuthState) postLuaAction(passDBResult *PassDBResult) {
 
 					return ""
 				}(),
+				AccountField:        a.getAccountField(),
 				UniqueUserID:        a.getUniqueUserID(),
 				DisplayName:         a.getDisplayName(),
 				Password:            a.Password,
@@ -1625,6 +1637,7 @@ func (a *AuthState) filterLua(passDBResult *PassDBResult, ctx *gin.Context) glob
 
 				return ""
 			}(),
+			AccountField:        a.getAccountField(),
 			UniqueUserID:        a.getUniqueUserID(),
 			DisplayName:         a.getDisplayName(),
 			Password:            a.Password,

--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -818,6 +818,7 @@ func (a *AuthState) checkBruteForce() (blockClientIP bool) {
 					UserAgent:           *a.UserAgent,
 					Username:            a.Username,
 					Account:             "", // unavailable
+					AccountField:        "", // unavailable
 					UniqueUserID:        "", // unavailable
 					DisplayName:         "", // unavailable
 					Password:            a.Password,

--- a/server/core/features.go
+++ b/server/core/features.go
@@ -118,6 +118,7 @@ func (a *AuthState) featureLua(ctx *gin.Context) (triggered bool, abortFeatures 
 			LocalPort:           a.XPort,
 			Username:            a.Username,
 			Account:             "", // unavailable
+			AccountField:        "", // unavailable
 			UniqueUserID:        "", // unavailable
 			DisplayName:         "", // unavailable
 			Password:            a.Password,

--- a/server/core/lua.go
+++ b/server/core/lua.go
@@ -63,9 +63,10 @@ func luaPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 			LocalIP:             auth.XLocalIP,
 			LocalPort:           auth.XPort,
 			Username:            auth.Username,
-			Account:             "", // set by backend_result
-			UniqueUserID:        "", // set by backend_result
-			DisplayName:         "", // set by backend_result
+			Account:             "", // set by nauthilus_backend_result
+			AccountField:        "", // set by nauthilus_backend_result
+			UniqueUserID:        "", // set by nauthilus_backend_result
+			DisplayName:         "", // set by nauthilus_backend_result
 			Password:            auth.Password,
 			Protocol:            auth.Protocol.Get(),
 			BruteForceName:      "", // unavailable

--- a/server/global/const.go
+++ b/server/global/const.go
@@ -1349,6 +1349,9 @@ const (
 	// LuaRequestAccount signifies the account of the user making the request.
 	LuaRequestAccount = "account"
 
+	// LuaRequestAccountField is a constant representing the key for the account field in a Lua request.
+	LuaRequestAccountField = "account_field"
+
 	// LuaRequestUniqueUserID signifies the unique user ID of the user making the request.
 	LuaRequestUniqueUserID = "unique_user_id"
 

--- a/server/lualib/request.go
+++ b/server/lualib/request.go
@@ -82,6 +82,9 @@ type CommonRequest struct {
 	// Account stores the user's account information.
 	Account string
 
+	// AccountField stores the user's account field.
+	AccountField string
+
 	// UniqueUserID stores the unique user identifier.
 	UniqueUserID string
 
@@ -197,6 +200,7 @@ func (c *CommonRequest) SetupRequest(request *lua.LTable) *lua.LTable {
 	request.RawSetString(global.LuaRequestLocalPort, lua.LString(c.LocalPort))
 	request.RawSetString(global.LuaRequestUsername, lua.LString(c.Username))
 	request.RawSetString(global.LuaRequestAccount, lua.LString(c.Account))
+	request.RawSetString(global.LuaRequestAccountField, lua.LString(c.AccountField))
 	request.RawSetString(global.LuaRequestUniqueUserID, lua.LString(c.UniqueUserID))
 	request.RawSetString(global.LuaRequestDisplayName, lua.LString(c.DisplayName))
 	request.RawSetString(global.LuaRequestPassword, lua.LString(c.Password))


### PR DESCRIPTION
Introduced the `AccountField` attribute in multiple authentication-related structs. Updated corresponding functions and Lua request handling to support the new field. This change ensures consistent handling of user account information across different modules.