### PR TITLE
Feat: Add ScriptName field to Lua script actions

### DIFF
--- a/server/config/lua.go
+++ b/server/config/lua.go
@@ -51,6 +51,7 @@ func (l *LuaSection) GetProtocols() any {
 
 type LuaAction struct {
 	ActionType string `mapstructure:"type"`
+	ScriptName string `mapstructure:"name"`
 	ScriptPath string `mapstructure:"script_path"`
 }
 
@@ -58,9 +59,14 @@ func (l *LuaAction) String() string {
 	return fmt.Sprintf("{ActionType: %s}, {ScriptPath: %s}", l.ActionType, l.ScriptPath)
 }
 
-// GetAction returns the action type and a path to a Lua script as defined in the LuaAction struct.
-func (l *LuaAction) GetAction() (string, string) {
-	return l.ActionType, l.ScriptPath
+// GetAction returns the ActionType, ScriptName, and ScriptPath of a LuaAction.
+// It is a method of the LuaAction struct.
+// The ActionType field represents the type of the Lua action.
+// The ScriptName field represents the name of the Lua script.
+// The ScriptPath field represents the path to the Lua script file.
+// It returns these values as strings.
+func (l *LuaAction) GetAction() (string, string, string) {
+	return l.ActionType, l.ScriptName, l.ScriptPath
 }
 
 type LuaFeature struct {

--- a/server/lualib/action/action.go
+++ b/server/lualib/action/action.go
@@ -50,6 +50,9 @@ type LuaScriptAction struct {
 	// ScriptCompiled is the compiled Lua function.
 	ScriptCompiled *lua.FunctionProto
 
+	// ScriptName is the descriptive name of the script
+	ScriptName string
+
 	// LuaAction is the type of Lua action.
 	LuaAction global.LuaAction
 }
@@ -173,12 +176,12 @@ func (aw *Worker) loadActionScriptsFromConfiguration() {
 //	aw.loadScriptAction(actionConfig)
 func (aw *Worker) loadScriptAction(actionConfig *config.LuaAction) {
 	luaAction := &LuaScriptAction{}
-	actionType, scriptPath := actionConfig.GetAction()
+	actionType, scriptName, scriptPath := actionConfig.GetAction()
 
 	luaAction.LuaAction = getLuaActionType(actionType)
 
 	if luaAction.LuaAction != global.LuaActionNone {
-		aw.loadScript(luaAction, scriptPath)
+		aw.loadScript(luaAction, scriptName, scriptPath)
 	}
 }
 
@@ -189,7 +192,7 @@ func (aw *Worker) loadScriptAction(actionConfig *config.LuaAction) {
 // Parameters:
 // - luaAction: a pointer to a LuaScriptAction object.
 // - scriptPath: the path to the Lua script file.
-func (aw *Worker) loadScript(luaAction *LuaScriptAction, scriptPath string) {
+func (aw *Worker) loadScript(luaAction *LuaScriptAction, scriptName string, scriptPath string) {
 	var (
 		err            error
 		scriptCompiled *lua.FunctionProto
@@ -202,6 +205,7 @@ func (aw *Worker) loadScript(luaAction *LuaScriptAction, scriptPath string) {
 	}
 
 	luaAction.ScriptPath = scriptPath
+	luaAction.ScriptName = scriptName
 	luaAction.ScriptCompiled = scriptCompiled
 	aw.actionScripts = append(aw.actionScripts, luaAction)
 }
@@ -382,7 +386,7 @@ func (aw *Worker) setupRequest(L *lua.LState) *lua.LTable {
 func getTaskName(action *LuaScriptAction) string {
 	actionName := getLuaActionName(action)
 
-	return fmt.Sprintf("%s:%s", actionName, action.ScriptPath)
+	return fmt.Sprintf("%s:%s", actionName, action.ScriptName)
 }
 
 // runScript executes the Lua script at the specified index.


### PR DESCRIPTION
The ScriptName field has been introduced to the Lua script actions for better descriptive handling. This field has been added to relevant structs and methods, and the GetAction function now returns the ActionType, ScriptName, and ScriptPath.