### PR TITLE
Feat: Add status message for GeoIP policy violations

### DIFF
--- a/server/lua-plugins.d/filters/geoip.lua
+++ b/server/lua-plugins.d/filters/geoip.lua
@@ -130,6 +130,8 @@ function nauthilus_call_filter(request)
                     nauthilus_context.context_set("rt", rt)
                 end
 
+                nauthilus_builtin.status_message_set("Policy violation")
+
                 return nauthilus_builtin.FILTER_REJECT, nauthilus_builtin.FILTER_RESULT_OK
             end
         else


### PR DESCRIPTION
Previously, policy violations in the GeoIP filter were logged without any user notification. This commit adds a status message to inform users when a policy violation occurs, improving transparency and user awareness.