### PR TITLE
Fix: Change version to variable and update local cache key

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -2644,10 +2644,12 @@ func (a *AuthState) getOauth2SubjectAndClaims(oauth2Client openapi.OAuth2Client)
 // The key is constructed by concatenating the Username, Password and  Service values using a null character ('\0')
 // as a separator.
 func (a *AuthState) generateLocalChacheKey() string {
-	return fmt.Sprintf("%s\000%s\000%s",
+	return fmt.Sprintf("%s\000%s\000%s\000%s",
 		a.Username,
 		a.Password,
-		a.Service)
+		a.Service,
+		a.Protocol.Get(),
+	)
 }
 
 // getFromLocalCache retrieves the AuthState object from the local cache using the generateLocalChacheKey() as the key.

--- a/server/main.go
+++ b/server/main.go
@@ -52,7 +52,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-const version = "dev"
+var version = "dev"
 
 var versionFlag = flag.Bool("version", false, "print version and exit")
 


### PR DESCRIPTION
Converted version constant to a variable in main.go to allow modification at runtime. Updated the `generateLocalChacheKey` function in auth.go to include the protocol in the cache key for improved uniqueness.