### PR TITLE
Fix: Add initMethodAndUserAgent to auth initialization

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -2049,6 +2049,21 @@ func setupHTTPBasiAuth(ctx *gin.Context, auth *AuthState) {
 	auth.withXSSL(ctx)
 }
 
+// initMethodAndUserAgent initializes the authentication method and user agent fields if they are not already set.
+func (a *AuthState) initMethodAndUserAgent() *AuthState {
+	if a.Method == nil {
+		method := ""
+		a.Method = &method
+	}
+
+	if a.UserAgent == nil {
+		userAgent := ""
+		a.UserAgent = &userAgent
+	}
+
+	return a
+}
+
 // setupAuth sets up the authentication based on the service parameter in the gin context.
 // It takes the gin context and an AuthState struct as input.
 //
@@ -2088,8 +2103,8 @@ func setupAuth(ctx *gin.Context, auth *AuthState) {
 		}
 	}
 
+	auth.initMethodAndUserAgent()
 	auth.withDefaults(ctx)
-
 	auth.setOperationMode(ctx)
 }
 

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -877,7 +877,7 @@ func (a *ApiConfig) handleLoginSkip() {
 		Protocol:          config.NewProtocol(global.ProtoOryHydra),
 	}
 
-	auth.withDefaults(a.ctx).withClientInfo(a.ctx).withLocalInfo(a.ctx).withUserAgent(a.ctx).withXSSL(a.ctx)
+	auth.withDefaults(a.ctx).withClientInfo(a.ctx).withLocalInfo(a.ctx).withUserAgent(a.ctx).withXSSL(a.ctx).initMethodAndUserAgent()
 
 	auth.Username = a.loginRequest.GetSubject()
 
@@ -1174,7 +1174,7 @@ func initializeAuthLogin(ctx *gin.Context) (*AuthState, error) {
 		return nil, err
 	}
 
-	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
+	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx).initMethodAndUserAgent()
 
 	if _, reject := auth.preproccessAuthRequest(ctx); reject {
 		return nil, errors.ErrBruteForceAttack


### PR DESCRIPTION
Ensure the authentication method and user agent fields are initialized if they are not already set. This guarantees these fields are consistently available during authentication processing.