### PR TITLE
Fix: Refactor brute force password handling methods

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1568,11 +1568,11 @@ func (a *AuthState) postVerificationProcesses(ctx *gin.Context, useCache bool, b
 				global.DbgAuth,
 				global.LogKeyGUID, a.GUID,
 				"authenticated", false,
-				global.LogKeyMsg, "Calling saveBruteForcePasswordToRedis()",
+				global.LogKeyMsg, "Calling saveFailedPasswordCounterInRedis()",
 			)
 
 			// Increase counters
-			a.saveBruteForcePasswordToRedis()
+			a.saveFailedPasswordCounterInRedis()
 		}
 
 		a.getAllPasswordHistories()

--- a/server/core/cache.go
+++ b/server/core/cache.go
@@ -74,8 +74,8 @@ func cachePassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 	}
 
 	if !passDBResult.Authenticated {
-		if key := auth.getBruteForcePasswordHistoryRedisHashKey(true); key != "" {
-			auth.loadBruteForcePasswordHistoryFromRedis(key)
+		if key := auth.getPasswordHistoryRedisHashKey(true); key != "" {
+			auth.loadPasswordHistoryFromRedis(key)
 		}
 
 		// Prevent password lookups for already known wrong passwords.


### PR DESCRIPTION
Renamed several methods and variables related to brute force password handling to improve clarity and consistency. The renamed methods now better reflect their purpose, such as `getPasswordHistoryRedisHashKey` and `saveFailedPasswordCounterInRedis`. These changes enhance readability and maintainability of the authentication logic.