### PR TITLE
Fix: Enhance Prometheus metrics with instance_name label

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -1066,7 +1066,7 @@ func parseFlagsAndPrintVersion() {
 // Then, it retrieves the InstanceInfo metric using the labels and assigns it to infoMetric.
 // Finally, it sets the value of infoMetric to 1.
 func initializeInstanceInfo() {
-	infoMetric := stats.InstanceInfo.With(prometheus.Labels{"version": version})
+	infoMetric := stats.InstanceInfo.With(prometheus.Labels{"instance_name": config.LoadableConfig.Server.InstanceName, "version": version})
 
 	infoMetric.Set(1)
 }

--- a/server/stats/statistics.go
+++ b/server/stats/statistics.go
@@ -77,7 +77,7 @@ var (
 			Name: "nauthilus_version_info",
 			Help: "Information about the version.",
 		},
-		[]string{"version"})
+		[]string{"instance_name", "version"})
 
 	// CurrentRequests is a Prometheus Gauge metric that tracks the number of current requests being processed by the server.
 	CurrentRequests = promauto.NewGauge(


### PR DESCRIPTION
Added the "instance_name" label to the InstanceInfo metric to provide more detailed information for monitoring purposes. This allows for better identification and tracking of metrics across different server instances.