### PR TITLE
Fix: Update timestamp methods to use UnixMilli

### DIFF
--- a/server/stats/statistics.go
+++ b/server/stats/statistics.go
@@ -53,7 +53,7 @@ func init() {
 
 			defer ReloadMutex.RUnlock()
 
-			return float64(LastReloadTime.Unix())
+			return float64(LastReloadTime.UnixMilli())
 		},
 	)
 
@@ -65,7 +65,7 @@ func init() {
 			Help: "Unix timestamp of the application start",
 		},
 		func() float64 {
-			return float64(startTime.Unix())
+			return float64(startTime.UnixMilli())
 		},
 	)
 }


### PR DESCRIPTION
Changed LastReloadTime and startTime to return Unix milliseconds instead of Unix seconds for better precision. This aligns timestamp formats across the system for consistency.