### PR TITLE
Fix: Fix TLS and improve X-Forwarded-For handling

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -2230,7 +2230,7 @@ func (a *AuthState) withClientInfo(ctx *gin.Context) *AuthState {
 			level.Error(log.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err.Error())
 		}
 
-		util.ProcessXForwardedFor(ctx, &a.ClientIP, &a.XClientPort)
+		util.ProcessXForwardedFor(ctx, &a.ClientIP, &a.XClientPort, &a.XSSL)
 	}
 
 	if config.LoadableConfig.Server.DNS.ResolveClientIP {

--- a/server/core/features.go
+++ b/server/core/features.go
@@ -174,7 +174,7 @@ func (a *AuthState) featureTLSEncryption() (triggered bool) {
 
 	defer stopTimer()
 
-	if a.isInNetwork(config.LoadableConfig.ClearTextList) {
+	if !a.isInNetwork(config.LoadableConfig.ClearTextList) {
 		logAddMessage(a, global.NoTLS, global.FeatureTLSEncryption)
 
 		triggered = true

--- a/server/core/http.go
+++ b/server/core/http.go
@@ -293,7 +293,7 @@ func protectEndpointMiddleware() gin.HandlerFunc {
 			clientIP, clientPort, _ = net.SplitHostPort(ctx.Request.RemoteAddr)
 		}
 
-		util.ProcessXForwardedFor(ctx, &clientIP, &clientPort)
+		util.ProcessXForwardedFor(ctx, &clientIP, &clientPort, &auth.XSSL)
 
 		if clientIP == "" {
 			clientIP = global.NotAvailable
@@ -499,8 +499,8 @@ func createMiddlewareChain(sessionStore sessions.Store) []gin.HandlerFunc {
 		sessions.Sessions(global.SessionName, sessionStore),
 		adapter.Wrap(nosurf.NewPure),
 		luaContextMiddleware(),
-		protectEndpointMiddleware(),
 		withLanguageMiddleware(),
+		protectEndpointMiddleware(),
 	}
 }
 

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -423,9 +423,6 @@ type ApiConfig struct {
 	// httpClient is a configured HTTP client used to establish connections to the OAuth2 OpenID-connect server.
 	httpClient *http.Client
 
-	// closeHTTPClient closes the HTTP client, releasing any resources associated with it.
-	closeHTTPClient func()
-
 	// apiClient holds the client information to interact with the OpenAPI.
 	apiClient *openapi.APIClient
 
@@ -1129,8 +1126,6 @@ func loginGETHandler(ctx *gin.Context) {
 
 	apiConfig.initialize()
 
-	defer apiConfig.closeHTTPClient()
-
 	apiConfig.challenge = loginChallenge
 	apiConfig.csrfToken = ctx.GetString(global.CtxCSRFTokenKey)
 
@@ -1662,8 +1657,6 @@ func loginPOSTHandler(ctx *gin.Context) {
 	apiConfig := &ApiConfig{ctx: ctx}
 
 	apiConfig.initialize()
-
-	defer apiConfig.closeHTTPClient()
 
 	apiConfig.challenge = loginChallenge
 
@@ -2215,8 +2208,6 @@ func consentGETHandler(ctx *gin.Context) {
 
 	apiConfig.initialize()
 
-	defer apiConfig.closeHTTPClient()
-
 	apiConfig.challenge = consentChallenge
 	apiConfig.csrfToken = ctx.GetString(global.CtxCSRFTokenKey)
 
@@ -2459,8 +2450,6 @@ func consentPOSTHandler(ctx *gin.Context) {
 
 	apiConfig.initialize()
 
-	defer apiConfig.closeHTTPClient()
-
 	apiConfig.challenge = consentChallenge
 
 	apiConfig.consentRequest, httpResponse, err = apiConfig.apiClient.OAuth2API.GetOAuth2ConsentRequest(ctx).ConsentChallenge(
@@ -2568,8 +2557,6 @@ func logoutGETHandler(ctx *gin.Context) {
 	apiConfig := ApiConfig{ctx: ctx}
 
 	apiConfig.initialize()
-
-	defer apiConfig.closeHTTPClient()
 
 	apiConfig.challenge = logoutChallenge
 	apiConfig.csrfToken = ctx.GetString(global.CtxCSRFTokenKey)
@@ -2718,8 +2705,6 @@ func logoutPOSTHandler(ctx *gin.Context) {
 	apiConfig := &ApiConfig{ctx: ctx}
 
 	apiConfig.initialize()
-
-	defer apiConfig.closeHTTPClient()
 
 	apiConfig.challenge = logoutChallenge
 

--- a/server/util/util.go
+++ b/server/util/util.go
@@ -405,7 +405,7 @@ func logTrustedProxy(guid string, fwdAddress, clientIP string) {
 // the client IP with the forwarded address and updates the client IP to the forwarded address.
 // If the forwarded address contains multiple IP addresses separated by a comma, the first
 // IP address is used as the client IP. The client port is set to "N/A".
-func ProcessXForwardedFor(ctx *gin.Context, clientIP, clientPort *string) {
+func ProcessXForwardedFor(ctx *gin.Context, clientIP, clientPort *string, xssl *string) {
 	fwdAddress := ctx.GetHeader("X-Forwarded-For")
 	guid := ctx.GetString(global.CtxGUIDKey)
 
@@ -428,6 +428,13 @@ func ProcessXForwardedFor(ctx *gin.Context, clientIP, clientPort *string) {
 		}
 
 		*clientPort = global.NotAvailable
+
+		if *xssl == "" {
+			proto := ctx.GetHeader("X-Forwarded-Proto")
+			if proto == "https" {
+				*xssl = "on"
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Correct inverted TLS check and enhance X-Forwarded-For processing to include protocol. Additionally, remove unused closeHTTPClient function calls to prevent panics.