### PR TITLE
Fix: Handle errors and abort on temp auth failure

### DIFF
--- a/server/core/http.go
+++ b/server/core/http.go
@@ -336,6 +336,11 @@ func protectEndpointMiddleware() gin.HandlerFunc {
 		case global.AuthResultOK:
 		case global.AuthResultFail:
 		case global.AuthResultTempFail:
+			auth.postLuaAction(&PassDBResult{})
+			auth.authTempFail(ctx, global.TempFailDefault)
+			ctx.Abort()
+
+			return
 		case global.AuthResultEmptyUsername:
 		case global.AuthResultEmptyPassword:
 		}

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -1715,6 +1715,7 @@ func loginPOSTHandler(ctx *gin.Context) {
 
 		apiConfig.logFailedLoginAndRedirect(auth)
 	default:
+		handleErr(ctx, errors.ErrUnknownCause)
 		ctx.AbortWithStatus(http.StatusInternalServerError)
 
 		return


### PR DESCRIPTION
Added an error handler for unknown causes in `hydra.go` to ensure consistent error handling. In `http.go`, introduced logic to manage temporary authentication failures, calling specific functions and aborting the context to prevent further processing.