### PR TITLE
Refactor error handling in `checkBruteForcePrevention`

### DIFF
--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -103,15 +103,11 @@ func (a *AuthState) userExists() (bool, error) {
 	accountName, err := backend.LookupUserAccountFromRedis(a.HTTPClientContext, a.Username)
 	if err != nil {
 		return false, err
-	} else {
-		stats.RedisReadCounter.Inc()
 	}
 
-	if accountName == "" {
-		return false, nil
-	}
+	stats.RedisReadCounter.Inc()
 
-	return true, nil
+	return accountName != "", nil
 }
 
 // checkEnforceBruteForceComputation checks the enforcement rules for brute force computation.


### PR DESCRIPTION
Move RedisReadCounter increment outside the error check clause to ensure it is always executed. Simplify the return statement for clarity and brevity.