### PR TITLE
Fix: Add Redis key expiration for negative cache TTL

### DIFF
--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -653,6 +653,12 @@ func (a *AuthState) processPWHist() (accountName string) {
 
 	stats.RedisWriteCounter.Inc()
 
+	if err = rediscli.WriteHandle.Expire(a.HTTPClientContext, key, time.Duration(config.LoadableConfig.Server.Redis.NegCacheTTL)*time.Second).Err(); err != nil {
+		level.Error(log.Logger).Log(global.LogKeyGUID, a.GUID, global.LogKeyError, err)
+	}
+
+	stats.RedisWriteCounter.Inc()
+
 	return
 }
 


### PR DESCRIPTION
Implement Redis key expiration using NegCacheTTL configuration. Add error logging for potential failures during the expiration setting. Increment RedisWriteCounter for monitoring purposes.