### PR TITLE
Fix: Refactor Redis cache handling and brute force counter logic

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1616,10 +1616,12 @@ func (a *AuthState) postVerificationProcesses(ctx *gin.Context, useCache bool, b
 						DisplayNameField:  a.DisplayNameField,
 						Password: func() string {
 							if a.Password != "" {
-								return util.GetHash(util.PreparePassword(a.Password))
+								passwordShort := util.GetHash(util.PreparePassword(a.Password))
+
+								return passwordShort
 							}
 
-							return a.Password
+							return ""
 						}(),
 						Backend:    a.SourcePassDBBackend,
 						Attributes: a.Attributes,

--- a/server/core/cache.go
+++ b/server/core/cache.go
@@ -49,7 +49,9 @@ func cachePassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 		if accountName != "" {
 			redisPosUserKey := config.LoadableConfig.Server.Redis.Prefix + "ucp:" + cacheName + ":" + accountName
 
-			if _, err = backend.LoadCacheFromRedis(auth.HTTPClientContext, redisPosUserKey, &ppc); err != nil {
+			ppc = &backend.PositivePasswordCache{}
+
+			if _, err = backend.LoadCacheFromRedis(auth.HTTPClientContext, redisPosUserKey, ppc); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
Initialize PositivePasswordCache before LoadCacheFromRedis call and remove BruteForceBucketCache type. Replace generic RedisCache with PositivePasswordCache and refactor brute force counter functions to use a new load function.