### PR TITLE
Fix: Fix in-memory cache

### DIFF
--- a/server/core/http.go
+++ b/server/core/http.go
@@ -179,10 +179,8 @@ func requestHandler(ctx *gin.Context) {
 				return
 			}
 
-			if found, reject := auth.preproccessAuthRequest(ctx); reject {
+			if reject := auth.preproccessAuthRequest(ctx); reject {
 				return
-			} else if found {
-				auth.withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 			}
 
 			switch ctx.Param("service") {

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -1170,7 +1170,7 @@ func initializeAuthLogin(ctx *gin.Context) (*AuthState, error) {
 
 	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx).initMethodAndUserAgent()
 
-	if _, reject := auth.preproccessAuthRequest(ctx); reject {
+	if reject := auth.preproccessAuthRequest(ctx); reject {
 		return nil, errors.ErrBruteForceAttack
 	}
 

--- a/server/core/register.go
+++ b/server/core/register.go
@@ -290,12 +290,10 @@ func loginPOST2FAHandler(ctx *gin.Context) {
 
 	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 
-	if found, reject := auth.preproccessAuthRequest(ctx); reject {
+	if reject := auth.preproccessAuthRequest(ctx); reject {
 		handleErr(ctx, errors.ErrBruteForceAttack)
 
 		return
-	} else if found {
-		auth.withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 	}
 
 	if authResult == definitions.AuthResultUnset {


### PR DESCRIPTION
Refactor various functions to use the PassDBResult instead of AuthState. This simplifies the core logic and eliminates restoring state information.