### PR TITLE
Fix: Remove error handling for setStatusCodes

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1115,21 +1115,17 @@ func updateAuthentication(a *AuthState, passDBResult *PassDBResult, passDB *Pass
 }
 
 // setStatusCodes sets different status codes for various services.
-func (a *AuthState) setStatusCodes(service string) error {
+func (a *AuthState) setStatusCodes(service string) {
 	switch service {
 	case definitions.ServNginx:
 		a.StatusCodeOK = http.StatusOK
 		a.StatusCodeInternalError = http.StatusOK
 		a.StatusCodeFail = http.StatusOK
-	case definitions.ServSaslauthd, definitions.ServBasic, definitions.ServOryHydra, definitions.ServHeader, definitions.ServJSON:
+	default:
 		a.StatusCodeOK = http.StatusOK
 		a.StatusCodeInternalError = http.StatusInternalServerError
 		a.StatusCodeFail = http.StatusForbidden
-	default:
-		return errors.ErrUnknownService
 	}
-
-	return nil
 }
 
 // getUserAccountFromCache fetches the user account name from Redis cache using the provided username.
@@ -2315,15 +2311,8 @@ func NewAuthState(ctx *gin.Context) *AuthState {
 
 	guid := ctx.GetString(definitions.CtxGUIDKey)
 
-	if err := auth.setStatusCodes(ctx.Param("service")); err != nil {
-
-		level.Error(log.Logger).Log(definitions.LogKeyGUID, guid, definitions.LogKeyMsg, err)
-
-		return nil
-	}
-
+	auth.setStatusCodes(ctx.Param("service"))
 	setupAuth(ctx, auth)
-
 	logNewAuthState(guid, auth)
 
 	if ctx.Errors.Last() != nil {

--- a/server/core/hydra.go
+++ b/server/core/hydra.go
@@ -878,11 +878,7 @@ func (a *ApiConfig) handleLoginSkip() {
 
 	auth.Username = a.loginRequest.GetSubject()
 
-	if err := auth.setStatusCodes(definitions.ServOryHydra); err != nil {
-		handleErr(a.ctx, err)
-
-		return
-	}
+	auth.setStatusCodes(definitions.ServOryHydra)
 
 	if authStatus := auth.handlePassword(a.ctx); authStatus == definitions.AuthResultOK {
 		if config.LoadableConfig.Oauth2 != nil {
@@ -1164,10 +1160,7 @@ func initializeAuthLogin(ctx *gin.Context) (*AuthState, error) {
 		return nil, errors.ErrInvalidUsername
 	}
 
-	if err := auth.setStatusCodes(definitions.ServOryHydra); err != nil {
-		return nil, err
-	}
-
+	auth.setStatusCodes(definitions.ServOryHydra)
 	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx).initMethodAndUserAgent()
 
 	if reject := auth.preproccessAuthRequest(ctx); reject {

--- a/server/core/register.go
+++ b/server/core/register.go
@@ -253,7 +253,6 @@ func loginPOST2FAHandler(ctx *gin.Context) {
 	var (
 		authCompleteWithOK   bool
 		authCompleteWithFail bool
-		err                  error
 		guid                 = ctx.GetString(definitions.CtxGUIDKey)
 	)
 
@@ -282,12 +281,7 @@ func loginPOST2FAHandler(ctx *gin.Context) {
 		return
 	}
 
-	if err = auth.setStatusCodes(definitions.ServOryHydra); err != nil {
-		handleErr(ctx, err)
-
-		return
-	}
-
+	auth.setStatusCodes(definitions.ServOryHydra)
 	auth.withDefaults(ctx).withClientInfo(ctx).withLocalInfo(ctx).withUserAgent(ctx).withXSSL(ctx)
 
 	if reject := auth.preproccessAuthRequest(ctx); reject {

--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -80,7 +80,6 @@ func NewDetailedError(err string) *DetailedError {
 
 var (
 	ErrNoBackendsConfigured                    = errors.New("no database backends configured")
-	ErrUnknownService                          = errors.New("unknown service")
 	ErrAllBackendConfigError                   = errors.New("configuration errors in all Database sections")
 	ErrUnsupportedMediaType                    = errors.New("unsupported media type")
 	ErrFeatureBackendServersMonitoringDisabled = errors.New("backend_server_monitoring not enabled")


### PR DESCRIPTION
Eliminated error returns and handling for the setStatusCodes method across multiple files. This change simplifies the code by assuming predefined status codes for known services and default values for others. Additionally, removed the now unused ErrUnknownService error definition.