### PR TITLE
Fix: Refactor and standardize function names

### DIFF
--- a/server/core/bindjson.go
+++ b/server/core/bindjson.go
@@ -29,8 +29,8 @@ func getErrorMsg(fe validator.FieldError) string {
 	return "Unknown error"
 }
 
-// handleJSONError handles JSON validation errors by aborting the request and returning a JSON response with error details.
-func handleJSONError(ctx *gin.Context, err error) {
+// HandleJSONError handles JSON validation errors by aborting the request and returning a JSON response with error details.
+func HandleJSONError(ctx *gin.Context, err error) {
 	var validationErrors validator.ValidationErrors
 
 	if errors.As(err, &validationErrors) {

--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -957,7 +957,7 @@ func (a *AuthState) checkRepeatingBruteForcer(rules []config.BruteForceRule, net
 	return withError, alreadyTriggered, ruleNumber
 }
 
-// checkBruteForce is a method of the `AuthState` struct and is responsible for
+// CheckBruteForce is a method of the `AuthState` struct and is responsible for
 // telling whether the client IP should be blocked due to unrestricted unauthorized access attempts
 // (i.e., a Brute Force attack on the system).
 //
@@ -974,7 +974,7 @@ func (a *AuthState) checkRepeatingBruteForcer(rules []config.BruteForceRule, net
 //     the appropriate message, and runs a Lua script for handling the detected brute force attempt.
 //
 // It returns 'true' if a Brute Force attack is detected, otherwise returns 'false'.
-func (a *AuthState) checkBruteForce() (blockClientIP bool) {
+func (a *AuthState) CheckBruteForce() (blockClientIP bool) {
 	var (
 		ruleTriggered bool
 		message       string
@@ -1055,7 +1055,7 @@ func (a *AuthState) checkBruteForce() (blockClientIP bool) {
 	return a.processBruteForce(ruleTriggered, alreadyTriggered, &rules[ruleNumber], network, message)
 }
 
-// updateBruteForceBucketsCounter updates the brute force buckets counter for the current authentication
+// UpdateBruteForceBucketsCounter updates the brute force buckets counter for the current authentication
 // It checks if brute force is enabled for the current protocol and if the client IP is not in the whitelist
 // Then it iterates through the loaded brute force rules and saves the bucket counter to Redis
 // The method also logs debug information related to the authentication
@@ -1064,7 +1064,7 @@ func (a *AuthState) checkBruteForce() (blockClientIP bool) {
 //   - a: a pointer to the AuthState struct which contains the authentication details
 //
 // Returns: none
-func (a *AuthState) updateBruteForceBucketsCounter() {
+func (a *AuthState) UpdateBruteForceBucketsCounter() {
 	if !config.LoadableConfig.HasFeature(definitions.FeatureBruteForce) {
 		return
 	}

--- a/server/core/cache.go
+++ b/server/core/cache.go
@@ -23,8 +23,8 @@ import (
 	"github.com/croessner/nauthilus/server/util"
 )
 
-// cachePassDB implements the redis password database backend.
-func cachePassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
+// CachePassDB implements the redis password database backend.
+func CachePassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 	var (
 		accountName string
 		ppc         *backend.PositivePasswordCache

--- a/server/core/features.go
+++ b/server/core/features.go
@@ -85,8 +85,8 @@ func logAddLocalhost(auth *AuthState, feature string) {
 	auth.AdditionalLogs = append(auth.AdditionalLogs, definitions.Localhost)
 }
 
-// featureLua runs Lua scripts and returns a trigger result.
-func (a *AuthState) featureLua(ctx *gin.Context) (triggered bool, abortFeatures bool, err error) {
+// FeatureLua runs Lua scripts and returns a trigger result.
+func (a *AuthState) FeatureLua(ctx *gin.Context) (triggered bool, abortFeatures bool, err error) {
 	if isLocalOrEmptyIP(a.ClientIP) {
 		logAddLocalhost(a, definitions.FeatureLua)
 
@@ -162,8 +162,8 @@ func (a *AuthState) featureLua(ctx *gin.Context) (triggered bool, abortFeatures 
 	return
 }
 
-// featureTLSEncryption checks, if the remote client connection was secured.
-func (a *AuthState) featureTLSEncryption() (triggered bool) {
+// FeatureTLSEncryption checks, if the remote client connection was secured.
+func (a *AuthState) FeatureTLSEncryption() (triggered bool) {
 	if isLocalOrEmptyIP(a.ClientIP) {
 		logAddLocalhost(a, definitions.FeatureTLSEncryption)
 
@@ -193,9 +193,9 @@ func (a *AuthState) featureTLSEncryption() (triggered bool) {
 	return
 }
 
-// featureRelayDomains triggers if a user sent an email address as a login name and the domain component does not
+// FeatureRelayDomains triggers if a user sent an email address as a login name and the domain component does not
 // match the list of known domains.
-func (a *AuthState) featureRelayDomains() (triggered bool) {
+func (a *AuthState) FeatureRelayDomains() (triggered bool) {
 	if config.LoadableConfig.RelayDomains == nil {
 		return
 	}
@@ -361,10 +361,10 @@ func (a *AuthState) checkRBLs(ctx *gin.Context) (totalRBLScore int, err error) {
 	return
 }
 
-// featureRBLs is a method that checks if the client IP address is whitelisted, and then performs an RBL check
+// FeatureRBLs is a method that checks if the client IP address is whitelisted, and then performs an RBL check
 // on the client's IP address. If the RBL score exceeds the configured threshold, the 'triggered' flag is set to true.
 // It returns the 'triggered' flag and any error that occurred during the check.
-func (a *AuthState) featureRBLs(ctx *gin.Context) (triggered bool, err error) {
+func (a *AuthState) FeatureRBLs(ctx *gin.Context) (triggered bool, err error) {
 	var (
 		totalRBLScore int
 	)

--- a/server/core/ldap.go
+++ b/server/core/ldap.go
@@ -110,10 +110,10 @@ func restoreMasterUserTOTPSecret(passDBResult *PassDBResult, totpSecretPre []any
 	}
 }
 
-// ldapPassDB implements the LDAP password database backend.
+// LDAPPassDB implements the LDAP password database backend.
 //
 //nolint:gocognit // Backends are complex
-func ldapPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
+func LDAPPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 	var (
 		assertOk           bool
 		accountField       string
@@ -262,7 +262,7 @@ func ldapPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 	if auth.MasterUserMode {
 		auth.NoAuth = true
 
-		passDBResult, err = ldapPassDB(auth)
+		passDBResult, err = LDAPPassDB(auth)
 
 		restoreMasterUserTOTPSecret(passDBResult, totpSecretPre, protocol.TOTPSecretField)
 	}

--- a/server/core/lua.go
+++ b/server/core/lua.go
@@ -23,8 +23,8 @@ import (
 	"github.com/croessner/nauthilus/server/stats"
 )
 
-// luaPassDB implements the Lua password database backend.
-func luaPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
+// LuaPassDB implements the Lua password database backend.
+func LuaPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 	var luaBackendResult *lualib.LuaBackendResult
 
 	stopTimer := stats.PrometheusTimer(definitions.PromBackend, "lua_backend_request_total")

--- a/server/core/webauthn.go
+++ b/server/core/webauthn.go
@@ -115,8 +115,8 @@ func updateUser(ctx *gin.Context, user *backend.User) {
 	backend.SaveWebAuthnToRedis(ctx, user, config.LoadableConfig.Server.Redis.PosCacheTTL)
 }
 
-// Page: '/2fa/v1/webauthn/register/begin'
-func beginRegistration(ctx *gin.Context) {
+// BeginRegistration Page: '/2fa/v1/webauthn/register/begin'
+func BeginRegistration(ctx *gin.Context) {
 	var (
 		userName     string
 		displayName  string
@@ -233,8 +233,8 @@ func beginRegistration(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, options)
 }
 
-// Page: '/2fa/v1/webauthn/register/finish'
-func finishRegistration(ctx *gin.Context) {
+// FinishRegistration Page: '/2fa/v1/webauthn/register/finish'
+func FinishRegistration(ctx *gin.Context) {
 	var (
 		userName     string
 		uniqueUserID string


### PR DESCRIPTION
Refactor code by standardizing function names with consistent capitalization across the codebase to improve readability and maintainability. This involves changing the function names to use PascalCase instead of snake_case or mixed casing, ensuring improved alignment with Go naming conventions. Additionally, redundant Content-Type headers were removed to clean up the code. This refactoring effort enhances code clarity and consistency without altering existing functionality.