### PR TITLE
Fix: Reorder whitelist checks for brute force protection.

### DIFF
--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -1010,19 +1010,19 @@ func (a *AuthState) CheckBruteForce() (blockClientIP bool) {
 		return false
 	}
 
-	if len(config.LoadableConfig.BruteForce.IPWhitelist) > 0 {
-		if a.IsInNetwork(config.LoadableConfig.BruteForce.IPWhitelist) {
+	if config.LoadableConfig.BruteForce.HasSoftWhitelist() {
+		if util.IsSoftWhitelisted(a.Username, a.ClientIP, *a.GUID, config.LoadableConfig.BruteForce.SoftWhitelist) {
 			a.AdditionalLogs = append(a.AdditionalLogs, definitions.LogKeyBruteForce)
-			a.AdditionalLogs = append(a.AdditionalLogs, definitions.Whitelisted)
+			a.AdditionalLogs = append(a.AdditionalLogs, definitions.SoftWhitelisted)
 
 			return false
 		}
 	}
 
-	if config.LoadableConfig.BruteForce.HasSoftWhitelist() {
-		if util.IsSoftWhitelisted(a.Username, a.ClientIP, *a.GUID, config.LoadableConfig.BruteForce.SoftWhitelist) {
+	if len(config.LoadableConfig.BruteForce.IPWhitelist) > 0 {
+		if a.IsInNetwork(config.LoadableConfig.BruteForce.IPWhitelist) {
 			a.AdditionalLogs = append(a.AdditionalLogs, definitions.LogKeyBruteForce)
-			a.AdditionalLogs = append(a.AdditionalLogs, definitions.SoftWhitelisted)
+			a.AdditionalLogs = append(a.AdditionalLogs, definitions.Whitelisted)
 
 			return false
 		}


### PR DESCRIPTION
Swapped the order of IPWhitelist and SoftWhitelist checks in the brute force logic. This change prioritizes the evaluation of soft whitelisting over IP whitelisting, ensuring that users in the soft whitelist are handled first. This reordering aims to potentially improve performance and logical flow in specific scenarios.