### PR TITLE
Fix: Remove redundant error logging for Lua filter execution

### DIFF
--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -214,7 +214,6 @@ var (
 	ErrNoFiltersDefined         = errors.New("no filters defined")
 	ErrFilterLuaNameMissing     = errors.New("filter 'name' sttribute missing")
 	ErrFilterLuaScriptPathEmpty = errors.New("filter 'script_path' attribute missing")
-	ErrFilterFailed             = errors.New("filter failed")
 )
 
 // misc.


### PR DESCRIPTION
This commit removes redundant error logging that was previously performed during Lua filter script execution. By eliminating the `logError` function, errors are now managed more efficiently without unnecessary duplication in the logging process. Additionally, adjustments have been made to handle error returns directly, simplifying the error handling flow and enhancing readability.