### PR TITLE
Fix: Chicken-egg problem solved

### DIFF
--- a/server/lua-plugins.d/filters/monitoring.lua
+++ b/server/lua-plugins.d/filters/monitoring.lua
@@ -218,7 +218,7 @@ function nauthilus_call_filter(request)
     nauthilus_util.print_result({ log_format = request.log_format }, result, nil)
 
     if server_host == nil then
-        error("No backend servers are available")
+        return nauthilus_builtin.FILTER_ACCEPT, nauthilus_builtin.FILTER_RESULT_FAIL
     end
 
     return nauthilus_builtin.FILTER_ACCEPT, nauthilus_builtin.FILTER_RESULT_OK


### PR DESCRIPTION
If all monitored backend servers went down, Nauthilus raised an error, which was hindering all the backend servers to come online back again. The solution is to only log failures in filters and not to raise hard errors.