### PR TITLE
Fix: Return 404 response when Lua script is not found

### DIFF
--- a/contrib/imap-server/imap-server.go
+++ b/contrib/imap-server/imap-server.go
@@ -18,9 +18,11 @@ package main
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/emersion/go-imap"
@@ -82,6 +84,7 @@ type Backend struct{}
 
 func (b *Backend) Login(connInfo *imap.ConnInfo, username string, password string) (user backend.User, err error) {
 	_ = password
+
 	log.Println("Connect from", connInfo.RemoteAddr.String(), "username", username)
 
 	user = &User{name: username}
@@ -91,50 +94,172 @@ func (b *Backend) Login(connInfo *imap.ConnInfo, username string, password strin
 	return user, errContactSupport
 }
 
-func main() {
-	be := &Backend{}
+type proxyAndTLSListener struct {
+	proxyListener *proxyproto.Listener
+	tlsConfig     *tls.Config
+}
 
-	// Create a new server
-	s := server.New(be)
+func (p *proxyAndTLSListener) Accept() (net.Conn, error) {
+	rawConn, err := p.proxyListener.Accept()
+	if err != nil {
+		return nil, fmt.Errorf("failed to accept connection: %w", err)
+	}
 
-	address := os.Getenv("FAKE_IMAP_SERVER_ADDRESS")
+	tlsConn := tls.Server(rawConn, p.tlsConfig)
+
+	return tlsConn, nil
+}
+
+func (p *proxyAndTLSListener) Close() error {
+	return p.proxyListener.Close()
+}
+
+func (p *proxyAndTLSListener) Addr() net.Addr {
+	return p.proxyListener.Addr()
+}
+
+func NewProxyAndTLSListener(rawListener net.Listener, tlsConfig *tls.Config) net.Listener {
+	proxyListener := &proxyproto.Listener{
+		Listener: rawListener,
+		ConnPolicy: func(opts proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			return proxyproto.REQUIRE, nil
+		},
+	}
+
+	return &proxyAndTLSListener{
+		proxyListener: proxyListener,
+		tlsConfig:     tlsConfig,
+	}
+}
+
+type ServerConfig struct {
+	Address   string
+	TLSConfig *tls.Config
+}
+
+type IMAPType uint
+
+const (
+	IMAP IMAPType = iota
+	IMAPS
+)
+
+type IMAPServer struct {
+	serverDescription string
+	serverType        IMAPType
+	config            *ServerConfig
+	server            *server.Server
+}
+
+func NewIMAPServer(serverType IMAPType, serverDescription string, address string, backend backend.Backend) *IMAPServer {
+	return &IMAPServer{
+		serverDescription: serverDescription,
+		serverType:        serverType,
+		config: &ServerConfig{
+			Address:   address,
+			TLSConfig: configureTLS(),
+		},
+		server: server.New(backend),
+	}
+}
+
+func (s *IMAPServer) Start(wg *sync.WaitGroup) {
+	var listener net.Listener
+
+	defer wg.Done()
+
+	log.Printf("Starting %s server at %s", s.serverDescription, s.config.Address)
+
+	rawListener, err := net.Listen("tcp", s.config.Address)
+	if err != nil {
+		log.Fatalf("Failed to start %s server: %v", s.serverDescription, err)
+	}
+
+	if s.serverType == IMAPS {
+		listener = NewProxyAndTLSListener(rawListener, s.config.TLSConfig)
+	} else {
+		listener = &proxyproto.Listener{
+			Listener: rawListener,
+			ConnPolicy: func(opts proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+				return proxyproto.REQUIRE, nil
+			},
+		}
+
+		s.server.TLSConfig = s.config.TLSConfig
+	}
+
+	if err := s.server.Serve(listener); err != nil {
+		log.Fatalf("%s server stopped unexpectedly: %v", s.serverDescription, err)
+	}
+}
+
+type ServerManager struct {
+	wg    *sync.WaitGroup
+	imap  *IMAPServer
+	imaps *IMAPServer
+}
+
+func NewServerManager(backend *Backend) *ServerManager {
+	imapServer := NewIMAPServer(
+		IMAP,
+		"IMAP (StartTLS)",
+		getEnvWithDefault("FAKE_IMAP_SERVER_ADDRESS", "127.0.0.1:10143"),
+		backend,
+	)
+	imapsServer := NewIMAPServer(
+		IMAPS,
+		"IMAPS",
+		getEnvWithDefault("FAKE_IMAPS_SERVER_ADDRESS", "127.0.0.1:10993"),
+		backend,
+	)
+
+	return &ServerManager{
+		wg:    &sync.WaitGroup{},
+		imap:  imapServer,
+		imaps: imapsServer,
+	}
+}
+
+func (m *ServerManager) StartAll() {
+	m.wg.Add(2)
+
+	go m.imap.Start(m.wg)
+	go m.imaps.Start(m.wg)
+
+	m.wg.Wait()
+}
+
+func configureTLS() *tls.Config {
+	serverName := os.Getenv("FAKE_IMAP_SERVER_NAME")
 	tlsCert := os.Getenv("FAKE_IMAP_SERVER_TLSCERT")
 	tlsKey := os.Getenv("FAKE_IMAP_SERVER_TLSKEY")
 
-	if tlsCert != "" && tlsKey != "" {
-		cer, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
-		if err != nil {
-			log.Println(err)
-
-			return
-		}
-
-		s.TLSConfig = &tls.Config{
-			MinVersion:   tls.VersionTLS12,
-			Certificates: []tls.Certificate{cer},
-		}
+	if tlsCert == "" || tlsKey == "" {
+		log.Fatal("TLS certificate and key must be provided for IMAPS")
 	}
 
-	if address == "" {
-		address = "127.0.0.1:10143"
-	}
-
-	s.Addr = address
-	s.AllowInsecureAuth = true
-
-	log.Println("Starting IMAP server at", s.Addr)
-
-	// Set up listener
-	listener, err := net.Listen("tcp", s.Addr)
+	tlsCertificate, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to load TLS certificate: %v", err)
 	}
 
-	// Wrap listener in proxyproto
-	proxyListener := &proxyproto.Listener{Listener: listener}
-
-	// Start server
-	if err := s.Serve(proxyListener); err != nil {
-		log.Fatal(err)
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{tlsCertificate},
+		ServerName:   serverName,
 	}
+}
+
+func getEnvWithDefault(envVar, defaultValue string) string {
+	if value := os.Getenv(envVar); value != "" {
+		return value
+	}
+
+	return defaultValue
+}
+
+func main() {
+	manager := NewServerManager(&Backend{})
+
+	manager.StartAll()
 }

--- a/server/lualib/hook/hook.go
+++ b/server/lualib/hook/hook.go
@@ -371,7 +371,9 @@ func runLuaCustomWrapper(ctx *gin.Context, registerDynamicLoader func(*lua.LStat
 	hook := ctx.Param("hook")
 
 	if script = customLocation.GetScript(hook, ctx.Request.Method); script == nil {
-		return gin.H{}, fmt.Errorf("lua script for location '%s' not found", hook)
+		ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "lua script for location '" + hook + "' not found", "guid": guid})
+
+		return nil, nil
 	}
 
 	luaCtx, luaCancel := context.WithTimeout(ctx, viper.GetDuration("lua_script_timeout")*time.Second)


### PR DESCRIPTION
Previously, the system returned a generic error when a Lua script for a specific hook was missing. This update sends a 404 status with a JSON error response, improving clarity and aligning with standard HTTP practices.