### PR TITLE
Revert: Remove unnecessary length check in conversion logic.

### DIFF
--- a/server/lualib/convert/convert.go
+++ b/server/lualib/convert/convert.go
@@ -179,10 +179,6 @@ func LuaValueToGo(value lua.LValue) any {
 			return mp
 		}
 
-		if v.Len() == 0 {
-			return mp
-		}
-
 		array := make([]any, 0, v.Len())
 
 		v.ForEach(func(key lua.LValue, value lua.LValue) {


### PR DESCRIPTION
The length check for empty values was redundant and has been removed. The existing logic handles zero-length scenarios without requiring explicit validation, simplifying the code.