### PR TITLE
Feat: Support multiple backend pool configurations in channels

### DIFF
--- a/server/backend/lua.go
+++ b/server/backend/lua.go
@@ -69,11 +69,11 @@ func LuaMainWorker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			GetChannel().GetLuaChannel().GetLookupEndChan() <- bktype.Done{}
+			GetChannel().GetLuaChannel().GetLookupEndChan(DefaultBackendName) <- bktype.Done{}
 
 			return
 
-		case luaRequest := <-GetChannel().GetLuaChannel().GetLookupRequestChan():
+		case luaRequest := <-GetChannel().GetLuaChannel().GetLookupRequestChan(DefaultBackendName):
 			go handleLuaRequest(ctx, luaRequest, compiledScript)
 		}
 	}

--- a/server/core/ldap.go
+++ b/server/core/ldap.go
@@ -178,7 +178,7 @@ func LDAPPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 	}
 
 	// Find user with account status enabled
-	backend.GetChannel().GetLdapChannel().GetLookupRequestChan() <- ldapRequest
+	backend.GetChannel().GetLdapChannel().GetLookupRequestChan(backend.DefaultBackendName) <- ldapRequest
 
 	ldapReply = <-ldapReplyChan
 
@@ -237,7 +237,7 @@ func LDAPPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 			HTTPClientContext: auth.HTTPClientContext,
 		}
 
-		backend.GetChannel().GetLdapChannel().GetAuthRequestChan() <- ldapUserBindRequest
+		backend.GetChannel().GetLdapChannel().GetAuthRequestChan(backend.DefaultBackendName) <- ldapUserBindRequest
 
 		ldapReply = <-ldapReplyChan
 
@@ -336,7 +336,7 @@ func ldapAccountDB(auth *AuthState) (accounts AccountList, err error) {
 	}
 
 	// Find user with account status enabled
-	backend.GetChannel().GetLdapChannel().GetLookupRequestChan() <- ldapRequest
+	backend.GetChannel().GetLdapChannel().GetLookupRequestChan(backend.DefaultBackendName) <- ldapRequest
 
 	ldapReply = <-ldapReplyChan
 
@@ -427,7 +427,7 @@ func ldapAddTOTPSecret(auth *AuthState, totp *TOTPSecret) (err error) {
 	ldapRequest.ModifyAttributes = make(bktype.LDAPModifyAttributes, 2)
 	ldapRequest.ModifyAttributes[configField] = []string{totp.getValue()}
 
-	backend.GetChannel().GetLdapChannel().GetLookupRequestChan() <- ldapRequest
+	backend.GetChannel().GetLdapChannel().GetLookupRequestChan(backend.DefaultBackendName) <- ldapRequest
 
 	ldapReply = <-ldapReplyChan
 

--- a/server/core/lua.go
+++ b/server/core/lua.go
@@ -91,7 +91,7 @@ func LuaPassDB(auth *AuthState) (passDBResult *PassDBResult, err error) {
 		},
 	}
 
-	backend.GetChannel().GetLuaChannel().GetLookupRequestChan() <- luaRequest
+	backend.GetChannel().GetLuaChannel().GetLookupRequestChan(backend.DefaultBackendName) <- luaRequest
 
 	luaBackendResult = <-luaReplyChan
 
@@ -179,7 +179,7 @@ func luaAccountDB(auth *AuthState) (accounts AccountList, err error) {
 		},
 	}
 
-	backend.GetChannel().GetLuaChannel().GetLookupRequestChan() <- luaRequest
+	backend.GetChannel().GetLuaChannel().GetLookupRequestChan(backend.DefaultBackendName) <- luaRequest
 
 	luaBackendResult = <-luaReplyChan
 
@@ -232,7 +232,7 @@ func luaAddTOTPSecret(auth *AuthState, totp *TOTPSecret) (err error) {
 		},
 	}
 
-	backend.GetChannel().GetLuaChannel().GetLookupRequestChan() <- luaRequest
+	backend.GetChannel().GetLuaChannel().GetLookupRequestChan(backend.DefaultBackendName) <- luaRequest
 
 	luaBackendResult = <-luaReplyChan
 


### PR DESCRIPTION
Introduced pool-specific channel handling for LDAP and Lua backends to enable multiple backend pools. Updated interface methods to accept pool or backend names and ensured backward compatibility with a default pool setup. Added proper validation and error handling for pool-specific operations.