### PR TITLE
Fix: Add support for LDAP pool-only mode validation.

### DIFF
--- a/server/config/file.go
+++ b/server/config/file.go
@@ -1960,6 +1960,7 @@ func (f *FileSettings) HandleFile() (err error) {
 
 	validate.RegisterValidation("validateCookieStoreEncKey", validateCookieStoreEncKey)
 	validate.RegisterValidation("validateOptionalLuaBackend", validateOptionalLuaBackend)
+	validate.RegisterValidation("validatePoolOnly", validatePoolOnly)
 
 	if err = validate.Struct(f); err != nil {
 		if stderrors.As(err, &validationErrors) {

--- a/server/config/ldap.go
+++ b/server/config/ldap.go
@@ -22,12 +22,27 @@ import (
 
 	"github.com/croessner/nauthilus/server/definitions"
 	"github.com/croessner/nauthilus/server/errors"
+	"github.com/go-playground/validator/v10"
 )
 
 type LDAPSection struct {
 	Config            *LDAPConf            `mapstructure:"config" validate:"required"`
-	OptionalLDAPPools map[string]*LDAPConf `mapstructure:"optional_ldap_pools" validate:"omitempty,dive"`
+	OptionalLDAPPools map[string]*LDAPConf `mapstructure:"optional_ldap_pools" validate:"omitempty,dive,validatePoolOnly"`
 	Search            []LDAPSearchProtocol `mapstructure:"search" validate:"omitempty,dive"`
+}
+
+// validatePoolOnly checks if the LDAPConf instance has PoolOnly set to true and returns false if it does, otherwise true.
+func validatePoolOnly(fl validator.FieldLevel) bool {
+	ldapConf, ok := fl.Field().Interface().(LDAPConf)
+	if !ok {
+		return false
+	}
+
+	if ldapConf.PoolOnly {
+		return false
+	}
+
+	return true
 }
 
 func (l *LDAPSection) String() string {

--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1751,7 +1751,7 @@ func (a *AuthState) handleBackendTypes() (useCache bool, backendPos map[definiti
 			}
 		case definitions.BackendLDAP:
 			if !config.GetFile().LDAPHavePoolOnly() {
-				mgr := NewLDAPManager(backendType.GetName())
+				mgr := NewLDAPManager(backendType.GetName(), config.GetFile().LDAPHavePoolOnly())
 				passDBs = a.appendBackend(passDBs, definitions.BackendLDAP, mgr.PassDB)
 			}
 		case definitions.BackendLua:
@@ -2134,7 +2134,7 @@ func (a *AuthState) ListUserAccounts() (accountList AccountList) {
 		switch backendType.Get() {
 		case definitions.BackendLDAP:
 			if !config.GetFile().LDAPHavePoolOnly() {
-				mgr := NewLDAPManager(backendType.GetName())
+				mgr := NewLDAPManager(backendType.GetName(), config.GetFile().LDAPHavePoolOnly())
 				accounts = append(accounts, &AccountListMap{
 					definitions.BackendLDAP,
 					mgr.AccountDB,

--- a/server/core/ldap.go
+++ b/server/core/ldap.go
@@ -35,6 +35,9 @@ import (
 
 // ldapManagerImpl provides an implementation for managing LDAP connections and operations using a specific connection pool.
 type ldapManagerImpl struct {
+	// poolOnly indicates if only the LDAP connection pool should be utilized without any direct operations.
+	poolOnly bool
+
 	// poolName specifies the identifier for the LDAP connection pool to be utilized by the manager implementation.
 	poolName string
 }
@@ -132,6 +135,10 @@ func (lm *ldapManagerImpl) PassDB(auth *AuthState) (passDBResult *PassDBResult, 
 	)
 
 	passDBResult = &PassDBResult{}
+
+	if lm.poolOnly {
+		return
+	}
 
 	ldapReplyChan := make(chan *bktype.LDAPReply)
 
@@ -454,8 +461,9 @@ func ldapGetWebAuthnCredentials(uniqueUserID string) ([]webauthn.Credential, err
 var _ BackendManager = (*ldapManagerImpl)(nil)
 
 // NewLDAPManager creates and returns a BackendManager for managing LDAP authentication backends using the specified pool name.
-func NewLDAPManager(poolName string) BackendManager {
+func NewLDAPManager(poolName string, poolOnly bool) BackendManager {
 	return &ldapManagerImpl{
 		poolName: poolName,
+		poolOnly: poolOnly,
 	}
 }

--- a/server/core/register.go
+++ b/server/core/register.go
@@ -731,7 +731,7 @@ func RegisterTotpPOSTHandler(ctx *gin.Context) {
 	switch sourceBackend.(uint8) {
 	case uint8(definitions.BackendLDAP):
 		// We have no mapping to an optional LDAP pool!
-		addTOTPSecret = NewLDAPManager(definitions.DefaultBackendName).AddTOTPSecret
+		addTOTPSecret = NewLDAPManager(definitions.DefaultBackendName, false).AddTOTPSecret
 	case uint8(definitions.BackendLua):
 		// We have no mapping to an optional Lua backend!
 		addTOTPSecret = NewLuaManager(definitions.DefaultBackendName).AddTOTPSecret


### PR DESCRIPTION
Introduce a `poolOnly` flag in LDAP manager to restrict operations to connection pools only. Implement `validatePoolOnly` for configuration validation, ensuring proper use of pool-only mode. Update related methods and structures to handle this new behavior.