### PR TITLE
Fix: Refactor LDAP pool handling to support backend-specific queries

### DIFF
--- a/server/config/ldap.go
+++ b/server/config/ldap.go
@@ -22,27 +22,12 @@ import (
 
 	"github.com/croessner/nauthilus/server/definitions"
 	"github.com/croessner/nauthilus/server/errors"
-	"github.com/go-playground/validator/v10"
 )
 
 type LDAPSection struct {
 	Config            *LDAPConf            `mapstructure:"config" validate:"required"`
-	OptionalLDAPPools map[string]*LDAPConf `mapstructure:"optional_ldap_pools" validate:"omitempty,dive,validatePoolOnly"`
+	OptionalLDAPPools map[string]*LDAPConf `mapstructure:"optional_ldap_pools" validate:"omitempty,dive"`
 	Search            []LDAPSearchProtocol `mapstructure:"search" validate:"omitempty,dive"`
-}
-
-// validatePoolOnly checks if the LDAPConf instance has PoolOnly set to true and returns false if it does, otherwise true.
-func validatePoolOnly(fl validator.FieldLevel) bool {
-	ldapConf, ok := fl.Field().Interface().(LDAPConf)
-	if !ok {
-		return false
-	}
-
-	if ldapConf.PoolOnly {
-		return false
-	}
-
-	return true
 }
 
 func (l *LDAPSection) String() string {

--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1750,8 +1750,8 @@ func (a *AuthState) handleBackendTypes() (useCache bool, backendPos map[definiti
 				useCache = true
 			}
 		case definitions.BackendLDAP:
-			if !config.GetFile().LDAPHavePoolOnly() {
-				mgr := NewLDAPManager(backendType.GetName(), config.GetFile().LDAPHavePoolOnly())
+			if !config.GetFile().LDAPHavePoolOnly(backendType.GetName()) {
+				mgr := NewLDAPManager(backendType.GetName())
 				passDBs = a.appendBackend(passDBs, definitions.BackendLDAP, mgr.PassDB)
 			}
 		case definitions.BackendLua:
@@ -2133,8 +2133,8 @@ func (a *AuthState) ListUserAccounts() (accountList AccountList) {
 	for _, backendType := range config.GetFile().GetServer().GetBackends() {
 		switch backendType.Get() {
 		case definitions.BackendLDAP:
-			if !config.GetFile().LDAPHavePoolOnly() {
-				mgr := NewLDAPManager(backendType.GetName(), config.GetFile().LDAPHavePoolOnly())
+			if !config.GetFile().LDAPHavePoolOnly(backendType.GetName()) {
+				mgr := NewLDAPManager(backendType.GetName())
 				accounts = append(accounts, &AccountListMap{
 					definitions.BackendLDAP,
 					mgr.AccountDB,

--- a/server/core/ldap.go
+++ b/server/core/ldap.go
@@ -35,9 +35,6 @@ import (
 
 // ldapManagerImpl provides an implementation for managing LDAP connections and operations using a specific connection pool.
 type ldapManagerImpl struct {
-	// poolOnly indicates if only the LDAP connection pool should be utilized without any direct operations.
-	poolOnly bool
-
 	// poolName specifies the identifier for the LDAP connection pool to be utilized by the manager implementation.
 	poolName string
 }
@@ -135,10 +132,6 @@ func (lm *ldapManagerImpl) PassDB(auth *AuthState) (passDBResult *PassDBResult, 
 	)
 
 	passDBResult = &PassDBResult{}
-
-	if lm.poolOnly {
-		return
-	}
 
 	ldapReplyChan := make(chan *bktype.LDAPReply)
 
@@ -461,9 +454,8 @@ func ldapGetWebAuthnCredentials(uniqueUserID string) ([]webauthn.Credential, err
 var _ BackendManager = (*ldapManagerImpl)(nil)
 
 // NewLDAPManager creates and returns a BackendManager for managing LDAP authentication backends using the specified pool name.
-func NewLDAPManager(poolName string, poolOnly bool) BackendManager {
+func NewLDAPManager(poolName string) BackendManager {
 	return &ldapManagerImpl{
 		poolName: poolName,
-		poolOnly: poolOnly,
 	}
 }

--- a/server/core/register.go
+++ b/server/core/register.go
@@ -731,7 +731,7 @@ func RegisterTotpPOSTHandler(ctx *gin.Context) {
 	switch sourceBackend.(uint8) {
 	case uint8(definitions.BackendLDAP):
 		// We have no mapping to an optional LDAP pool!
-		addTOTPSecret = NewLDAPManager(definitions.DefaultBackendName, false).AddTOTPSecret
+		addTOTPSecret = NewLDAPManager(definitions.DefaultBackendName).AddTOTPSecret
 	case uint8(definitions.BackendLua):
 		// We have no mapping to an optional Lua backend!
 		addTOTPSecret = NewLuaManager(definitions.DefaultBackendName).AddTOTPSecret


### PR DESCRIPTION
Revised `LDAPHavePoolOnly` to accept a backend name, enabling backend-specific checks for pool-only configurations. Removed redundant `poolOnly` field in `ldapManagerImpl` and streamlined related logic. Simplified validation and worker initialization processes for clarity and efficiency.