### PR TITLE
Fix: Add custom validation for AuthPoolSize in LDAP configuration

### DIFF
--- a/server/config/file.go
+++ b/server/config/file.go
@@ -1982,6 +1982,7 @@ func (f *FileSettings) HandleFile() (err error) {
 
 	validate.RegisterValidation("validateCookieStoreEncKey", validateCookieStoreEncKey)
 	validate.RegisterValidation("validateOptionalLuaBackend", validateOptionalLuaBackend)
+	validate.RegisterValidation("validateAuthPoolRequired", validateAuthPoolRequired)
 
 	if err = validate.Struct(f); err != nil {
 		if stderrors.As(err, &validationErrors) {


### PR DESCRIPTION
Introduced `validateAuthPoolRequired` to ensure `AuthPoolSize` is greater than 0 when `PoolOnly` is false. Updated `LDAPConf` struct to utilize the new validator and refined existing validation rules for clarity and correctness.