### PR TITLE
Fix: Validate backend names to prevent use of reserved names

### DIFF
--- a/server/config/file.go
+++ b/server/config/file.go
@@ -1983,6 +1983,7 @@ func (f *FileSettings) HandleFile() (err error) {
 	validate.RegisterValidation("validateCookieStoreEncKey", validateCookieStoreEncKey)
 	validate.RegisterValidation("validateOptionalLuaBackend", validateOptionalLuaBackend)
 	validate.RegisterValidation("validateAuthPoolRequired", validateAuthPoolRequired)
+	validate.RegisterValidation("validatDefaultBackendName", validatDefaultBackendName)
 
 	if err = validate.Struct(f); err != nil {
 		if stderrors.As(err, &validationErrors) {

--- a/server/config/ldap.go
+++ b/server/config/ldap.go
@@ -27,8 +27,24 @@ import (
 
 type LDAPSection struct {
 	Config            *LDAPConf            `mapstructure:"config" validate:"required"`
-	OptionalLDAPPools map[string]*LDAPConf `mapstructure:"optional_ldap_pools" validate:"omitempty,dive"`
+	OptionalLDAPPools map[string]*LDAPConf `mapstructure:"optional_ldap_pools" validate:"omitempty,dive,validatDefaultBackendName"`
 	Search            []LDAPSearchProtocol `mapstructure:"search" validate:"omitempty,dive"`
+}
+
+// validatDefaultBackendName ensures the backend name is not set to "default" or the predefined DefaultBackendName constant.
+func validatDefaultBackendName(fl validator.FieldLevel) bool {
+	conf, ok := fl.Parent().Interface().(LDAPSection)
+	if !ok {
+		return false
+	}
+
+	for backendName := range conf.OptionalLDAPPools {
+		if backendName == "default" || backendName == definitions.DefaultBackendName {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (l *LDAPSection) String() string {

--- a/server/config/types.go
+++ b/server/config/types.go
@@ -240,7 +240,12 @@ func (b *Backend) Set(value string) error {
 	regex := regexp.MustCompile(`^(ldap|lua)\((.*?)\)$`)
 
 	if matches := regex.FindStringSubmatch(value); matches != nil {
-		b.name = strings.TrimSpace(matches[2])
+		name := strings.TrimSpace(matches[2])
+		if name == "default" || name == definitions.DefaultBackendName {
+			return fmt.Errorf(errors.ErrWrongPassDB.Error(), name)
+		}
+
+		b.name = name
 		value = matches[1]
 	}
 


### PR DESCRIPTION
Enforce rules to disallow using "default" or DefaultBackendName as backend names for LDAP configurations. Added validation logic in both the backend parsing and configuration schema to ensure compliance.