### PR TITLE
Remove unused mutex and add ML system initialization on startup

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -59,9 +59,11 @@ func main() {
 
 	inititalizeBruteForceTolerate(ctx)
 	initializeHTTPClients()
+	initializeMLMetrics(ctx)
 	setupWorkers(ctx, store, actionWorkers)
 	handleSignals(ctx, cancel, store, statsTicker, &monitoringTicker, actionWorkers)
 	setupRedis(ctx)
+
 	runLuaaInitScript(ctx)
 	core.LoadStatsFromRedis(ctx)
 	startHTTPServer(ctx, store)

--- a/server/server.go
+++ b/server/server.go
@@ -896,6 +896,22 @@ func initializeHTTPClients() {
 	ml.InitHTTPClient()
 }
 
+// initializeMLMetrics initializes and logs the status of the ML system during application startup.
+func initializeMLMetrics(ctx context.Context) {
+	// Initialize ML system
+	if err := ml.InitMLSystem(ctx); err != nil {
+		level.Error(log.Logger).Log(
+			definitions.LogKeyMsg, "Failed to initialize ML system",
+			definitions.LogKeyMsg, err,
+		)
+	} else {
+		level.Info(log.Logger).Log(
+			definitions.LogKeyMsg, "ML system initialized successfully",
+		)
+	}
+
+}
+
 // runConnectionManager initializes the ConnectionManager, registers the server address, and starts a ticker to update connection counts.
 func runConnectionManager(ctx context.Context) {
 	manager := connmgr.GetConnectionManager()


### PR DESCRIPTION
Eliminated redundant mutex from MLMetrics methods to simplify code and improve clarity. Introduced `initializeMLMetrics` to ensure the ML system is properly initialized and logged during application startup.