### PR TITLE
Fix: Refactor login recording to filter specific IPs and users

### DIFF
--- a/server/bruteforce/ml/integration.go
+++ b/server/bruteforce/ml/integration.go
@@ -184,7 +184,7 @@ func (m *MLBucketManager) ProcessBruteForce(ruleTriggered, alreadyTriggered bool
 					"additional_features", fmt.Sprintf("%+v", features.AdditionalFeatures),
 				)
 
-				_ = RecordLoginResult(m.ctx, false, features)
+				_ = RecordLoginResult(m.ctx, false, features, m.clientIP, m.username, m.guid)
 			}
 
 			// If static rules haven't triggered, check if ML detector would trigger
@@ -224,7 +224,7 @@ func (m *MLBucketManager) ProcessBruteForce(ruleTriggered, alreadyTriggered bool
 					)
 
 					// Record this detection for future ML training
-					_ = RecordLoginResult(m.ctx, false, features)
+					_ = RecordLoginResult(m.ctx, false, features, m.clientIP, m.username, m.guid)
 				} else {
 					// Log the state after ML prediction when no brute force is detected
 					util.DebugModule(definitions.DbgNeural,
@@ -283,7 +283,7 @@ func (m *MLBucketManager) RecordLoginFeature() {
 		features, err := m.mlDetector.CollectFeatures()
 		if err == nil {
 			// This is a triggered feature, so it's a failed login
-			_ = RecordLoginResult(m.ctx, false, features)
+			_ = RecordLoginResult(m.ctx, false, features, m.clientIP, m.username, m.guid)
 		}
 	}
 }
@@ -304,7 +304,7 @@ func (m *MLBucketManager) RecordSuccessfulLogin() {
 				"additional_features", fmt.Sprintf("%+v", features.AdditionalFeatures),
 			)
 
-			_ = RecordLoginResult(m.ctx, true, features)
+			_ = RecordLoginResult(m.ctx, true, features, m.clientIP, m.username, m.guid)
 		}
 	}
 }

--- a/server/bruteforce/ml/ml_detector_test.go
+++ b/server/bruteforce/ml/ml_detector_test.go
@@ -308,8 +308,8 @@ func TestRecordLoginResult(t *testing.T) {
 	// Expect LTRIM to keep the list at a manageable size
 	mock.ExpectLTrim("nauthilus:ml:training:data", 0, 9999).SetVal("OK")
 
-	// Record login result
-	err := RecordLoginResult(ctx, true, features)
+	// Record login result - use a non-localhost IP to avoid being filtered out
+	err := RecordLoginResult(ctx, true, features, "192.168.1.1", "testuser", "test-guid")
 	assert.NoError(t, err, "RecordLoginResult should not return an error")
 
 	// Verify all expectations were met

--- a/server/lualib/neural.go
+++ b/server/lualib/neural.go
@@ -27,9 +27,18 @@ func AddAdditionalFeatures(ctx context.Context) lua.LGFunction {
 		luaTable.ForEach(func(key, value lua.LValue) {
 			// Only string keys are supported
 			if keyStr, ok := key.(lua.LString); ok {
+				keyStrVal := string(keyStr)
+
+				// Skip ClientIP and Username as per requirements
+				if keyStrVal == "ClientIP" || keyStrVal == "client_ip" ||
+					keyStrVal == "Username" || keyStrVal == "username" {
+					// Skip these fields
+					return
+				}
+
 				// Convert Lua value to Go value using convert package
 				goValue := convert.LuaValueToGo(value)
-				features[string(keyStr)] = goValue
+				features[keyStrVal] = goValue
 			}
 		})
 


### PR DESCRIPTION
Introduced `ShouldIgnoreIP` to skip localhost, soft-whitelisted, and IP-whitelisted addresses from ML training. Updated `RecordLoginResult` to handle additional parameters: client IP, username, and GUID. Adjusted integration logic to reflect these changes, improving data filtering for ML models.