### PR TITLE
Fix: Add NoAuth mode to MLBucketManager for flexible authentication

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -1017,6 +1017,11 @@ func (a *AuthState) AuthOK(ctx *gin.Context) {
 			mlBM := ml.NewMLBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP).
 				WithUsername(a.Username).WithPassword(a.Password)
 
+			// Set NoAuth flag
+			if mlManager, ok := mlBM.(*ml.MLBucketManager); ok {
+				mlManager.SetNoAuth(a.NoAuth)
+			}
+
 			// Check if additional features are available from the Context
 			if a.Context != nil {
 				if features := lualib.GetAdditionalFeatures(a.Context); features != nil {
@@ -1854,6 +1859,11 @@ func (a *AuthState) processUserFound(passDBResult *PassDBResult) (accountName st
 					WithUsername(a.Username).
 					WithAccountName(accountName).
 					WithAccountName(accountName)
+
+				// Set NoAuth flag
+				if mlManager, ok := bm.(*ml.MLBucketManager); ok {
+					mlManager.SetNoAuth(a.NoAuth)
+				}
 			} else {
 				bm = bruteforce.NewBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP).
 					WithUsername(a.Username).
@@ -1980,6 +1990,11 @@ func (a *AuthState) processCacheUserLoginFail(accountName string) {
 			WithUsername(a.Username).
 			WithAccountName(accountName).
 			WithAccountName(accountName)
+
+		// Set NoAuth flag
+		if mlManager, ok := bm.(*ml.MLBucketManager); ok {
+			mlManager.SetNoAuth(a.NoAuth)
+		}
 	} else {
 		bm = bruteforce.NewBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP).
 			WithUsername(a.Username).
@@ -2009,6 +2024,11 @@ func (a *AuthState) processCache(authenticated bool, accountName string, useCach
 				WithUsername(a.Username).
 				WithAccountName(accountName).
 				WithAccountName(accountName)
+
+			// Set NoAuth flag
+			if mlManager, ok := bm.(*ml.MLBucketManager); ok {
+				mlManager.SetNoAuth(a.NoAuth)
+			}
 		} else {
 			bm = bruteforce.NewBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP).
 				WithUsername(a.Username).

--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -260,6 +260,11 @@ func (a *AuthState) CheckBruteForce() (blockClientIP bool) {
 
 		bm = ml.NewMLBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP)
 
+		// Set NoAuth flag
+		if mlBM, ok := bm.(*ml.MLBucketManager); ok {
+			mlBM.SetNoAuth(a.NoAuth)
+		}
+
 		// Check if additional features are available from the Context
 		if a.Context != nil {
 			if features := lualib.GetAdditionalFeatures(a.Context); features != nil {
@@ -381,6 +386,11 @@ func (a *AuthState) UpdateBruteForceBucketsCounter() {
 	if config.GetEnvironment().GetExperimentalML() {
 		mlBM := ml.NewMLBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP).
 			WithUsername(a.Username).WithPassword(a.Password)
+
+		// Set NoAuth flag
+		if mlManager, ok := mlBM.(*ml.MLBucketManager); ok {
+			mlManager.SetNoAuth(a.NoAuth)
+		}
 
 		// Check if additional features are available from the Context
 		if a.Context != nil {

--- a/server/core/rest.go
+++ b/server/core/rest.go
@@ -744,6 +744,11 @@ func processBruteForceRules(ctx *gin.Context, ipCmd *FlushRuleCmd, guid string) 
 		if rule.Name == ipCmd.RuleName || ipCmd.RuleName == "*" {
 			if config.GetEnvironment().GetExperimentalML() {
 				bm = ml.NewMLBucketManager(ctx, guid, ipCmd.IPAddress)
+
+				// Set NoAuth flag to false for administrative operations
+				if mlManager, ok := bm.(*ml.MLBucketManager); ok {
+					mlManager.SetNoAuth(false)
+				}
 			} else {
 				bm = bruteforce.NewBucketManager(ctx, guid, ipCmd.IPAddress)
 			}

--- a/server/lua-plugins.d/features/neural.lua
+++ b/server/lua-plugins.d/features/neural.lua
@@ -36,104 +36,102 @@ function nauthilus_call_neural_network(request)
         return
     end
 
-    if os.getenv("NAUTHILUS_EXPERIMENTAL_ML") == "true" then
-        -- For non-authenticated users, we still need to get the country code
-        dynamic_loader("nauthilus_prometheus")
-        local nauthilus_prometheus = require("nauthilus_prometheus")
+    -- For non-authenticated users, we still need to get the country code
+    dynamic_loader("nauthilus_prometheus")
+    local nauthilus_prometheus = require("nauthilus_prometheus")
 
-        dynamic_loader("nauthilus_gluahttp")
-        local http = require("glua_http")
+    dynamic_loader("nauthilus_gluahttp")
+    local http = require("glua_http")
 
-        dynamic_loader("nauthilus_gll_json")
-        local json = require("json")
+    dynamic_loader("nauthilus_gll_json")
+    local json = require("json")
 
-        local t = {}
+    local t = {}
 
-        t.key = "client"
-        t.value = {
-            address = request.client_ip,
-            sender = request.username
-        }
+    t.key = "client"
+    t.value = {
+        address = request.client_ip,
+        sender = request.username
+    }
 
-        local payload, json_encode_err = json.encode(t)
-        nauthilus_util.if_error_raise(json_encode_err)
+    local payload, json_encode_err = json.encode(t)
+    nauthilus_util.if_error_raise(json_encode_err)
 
-        nauthilus_prometheus.increment_gauge(HCCR, { service = N })
+    nauthilus_prometheus.increment_gauge(HCCR, { service = N })
 
-        local timer = nauthilus_prometheus.start_histogram_timer(N .. "_duration_seconds", { http = "post" })
-        local result, request_err = http.post(os.getenv("GEOIP_POLICY_URL") .. "?info=1", {
-            timeout = "10s",
-            headers = {
-                Accept = "*/*",
-                ["User-Agent"] = "Nauthilus",
-                ["Content-Type"] = "application/json",
-            },
-            body = payload,
-        })
+    local timer = nauthilus_prometheus.start_histogram_timer(N .. "_duration_seconds", { http = "post" })
+    local result, request_err = http.post(os.getenv("GEOIP_POLICY_URL") .. "?info=1", {
+        timeout = "10s",
+        headers = {
+            Accept = "*/*",
+            ["User-Agent"] = "Nauthilus",
+            ["Content-Type"] = "application/json",
+        },
+        body = payload,
+    })
 
-        nauthilus_prometheus.stop_timer(timer)
-        nauthilus_prometheus.decrement_gauge(HCCR, { service = N })
-        nauthilus_util.if_error_raise(request_err)
+    nauthilus_prometheus.stop_timer(timer)
+    nauthilus_prometheus.decrement_gauge(HCCR, { service = N })
+    nauthilus_util.if_error_raise(request_err)
 
-        if result.status_code ~= 202 then
-            nauthilus_util.if_error_raise(N .. "_status_code=" .. tostring(result.status_code))
-        end
+    if result.status_code ~= 202 then
+        nauthilus_util.if_error_raise(N .. "_status_code=" .. tostring(result.status_code))
+    end
 
-        local response, err_jdec = json.decode(result.body)
-        nauthilus_util.if_error_raise(err_jdec)
+    local response, err_jdec = json.decode(result.body)
+    nauthilus_util.if_error_raise(err_jdec)
 
-        if response.err == nil then
-            local current_iso_code = ""
+    if response.err == nil then
+        local current_iso_code = ""
 
-            if response.object then
-                -- Try to get the ISO country code
-                if nauthilus_util.is_table(response.object) then
-                    for key, values in pairs(response.object) do
-                        if key == "current_country_code" then
-                            if nauthilus_util.is_string(values) then
-                                current_iso_code = values
-                            end
+        if response.object then
+            -- Try to get the ISO country code
+            if nauthilus_util.is_table(response.object) then
+                for key, values in pairs(response.object) do
+                    if key == "current_country_code" then
+                        if nauthilus_util.is_string(values) then
+                            current_iso_code = values
                         end
                     end
                 end
             end
-
-            -- If country code is empty, set it to "unknown" (we know IP is routable)
-            if current_iso_code == "" then
-                current_iso_code = "unknown"
-            end
-
-            nauthilus_builtin.custom_log_add("country_code", current_iso_code)
-
-            local client_host = request.client_hostname
-            local client_id = request.client_id
-            local user_agent = request.user_agent
-
-            if not client_host or client_host == "" then
-                client_host = "unknown"
-            end
-
-            if not client_id or client_id == "" then
-                client_id = "unknown"
-            end
-
-            if not user_agent or user_agent == "" then
-                user_agent = "unknown"
-            end
-
-            -- Add country code to neural network
-            dynamic_loader("nauthilus_neural")
-            local nauthilus_neural = require("nauthilus_neural")
-
-            -- Add country code as a feature for non-authenticated users
-            -- Using the actual country code retrieved from the GeoIP service
-            nauthilus_neural.add_additional_features({
-                country_code = current_iso_code,
-                client_host = client_host,
-                client_id = client_id,
-                user_agent = user_agent,
-            })
         end
+
+        -- If country code is empty, set it to "unknown" (we know IP is routable)
+        if current_iso_code == "" then
+            current_iso_code = "unknown"
+        end
+
+        nauthilus_builtin.custom_log_add("country_code", current_iso_code)
+
+        local client_host = request.client_hostname
+        local client_id = request.client_id
+        local user_agent = request.user_agent
+
+        if not client_host or client_host == "" then
+            client_host = "unknown"
+        end
+
+        if not client_id or client_id == "" then
+            client_id = "unknown"
+        end
+
+        if not user_agent or user_agent == "" then
+            user_agent = "unknown"
+        end
+
+        -- Add country code to neural network
+        dynamic_loader("nauthilus_neural")
+        local nauthilus_neural = require("nauthilus_neural")
+
+        -- Add country code as a feature for non-authenticated users
+        -- Using the actual country code retrieved from the GeoIP service
+        nauthilus_neural.add_additional_features({
+            country_code = current_iso_code,
+            client_host = client_host,
+            client_id = client_id,
+            user_agent = user_agent,
+        })
     end
 
     return


### PR DESCRIPTION
Introduced a NoAuth flag in MLBucketManager to bypass authentication where necessary. Updated relevant methods and logic to respect this flag, ensuring login features are skipped in NoAuth mode while maintaining compatibility across services and features.