### PR TITLE
Fix: Enhance ML metrics descriptions and add training duration tracking

### DIFF
--- a/contrib/grafana/nauthilus-ml.json
+++ b/contrib/grafana/nauthilus-ml.json
@@ -184,7 +184,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Error during neural network training over time",
+      "description": "Shows the error during neural network training over time. A lower value means that the model is better adapted to the training data. The error is calculated as the average deviation between the predicted and actual values for all training data.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -398,7 +398,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Duration of neural network training",
+      "description": "Duration of neural network training in seconds. 'p95' means that 95% of training operations are faster than this value (95th percentile). 'p50' is the median value, where 50% of training operations are faster and 50% are slower. In the legend, 'success' indicates successful training operations, and 'failure' indicates failed training operations.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -513,7 +513,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Confidence score of neural network predictions",
+      "description": "Shows the probability (between 0 and 1) that the current login attempt is part of a brute force attack. Higher values indicate a higher probability of an attack. 'No data' is displayed when the neural network has not yet been trained or no predictions have been made.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -652,7 +652,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Duration of neural network prediction",
+      "description": "Shows the duration of neural network predictions in seconds. 'p95' means that 95% of predictions are faster than this value (95th percentile). 'p50' is the median value, where 50% of predictions are faster and 50% are slower. In the legend, 'true' indicates predictions where a brute force attack was detected, and 'false' indicates predictions where no brute force attack was detected. This metric helps to monitor the performance and response time of the ML system.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/server/bruteforce/ml/ml_detector.go
+++ b/server/bruteforce/ml/ml_detector.go
@@ -1121,10 +1121,17 @@ func (t *MLTrainer) TrainWithStoredData(maxSamples int, epochs int) error {
 		"epochs", epochs,
 	)
 
+	// Record the start time for training duration metric
+	startTime := time.Now()
+
 	t.model.Train(features, labels, epochs)
 
+	// Calculate and record the training duration
+	trainingDuration := time.Since(startTime).Seconds()
+	GetMLMetrics().RecordTrainingDuration(trainingDuration, true)
+
 	level.Info(log.Logger).Log(
-		definitions.LogKeyMsg, "Model training completed successfully",
+		definitions.LogKeyMsg, fmt.Sprintf("Model training completed successfully in %.2f seconds", trainingDuration),
 	)
 
 	// Set the modelTrained flag if we have enough data


### PR DESCRIPTION
Updated Grafana dashboard descriptions for better clarity on ML metrics, including error, duration, and prediction confidence. Added training duration measurement in `ml_detector.go` to log and track training performance.