### PR TITLE
Fix:`Make backend initialization conditional based on configuration`

### DIFF
--- a/server/backend/channels.go
+++ b/server/backend/channels.go
@@ -82,9 +82,20 @@ func GetChannel() Channel {
 
 // NewChannel initializes and returns a new instance of the Channel interface implementation.
 func NewChannel() Channel {
+	var ldapChannel LDAPChannel
+	var luaChannel LuaChannel
+
+	if config.GetFile().HaveLDAPBackend() {
+		ldapChannel = NewLDAPChannel(definitions.DefaultBackendName)
+	}
+
+	if config.GetFile().HaveLuaBackend() {
+		luaChannel = NewLuaChannel(definitions.DefaultBackendName)
+	}
+
 	return &channelImpl{
-		ldapChannel: NewLDAPChannel(definitions.DefaultBackendName),
-		luaChannel:  NewLuaChannel(definitions.DefaultBackendName),
+		ldapChannel: ldapChannel,
+		luaChannel:  luaChannel,
 	}
 }
 

--- a/server/config/file.go
+++ b/server/config/file.go
@@ -97,6 +97,9 @@ type File interface {
 	// HaveLua checks if Lua-based configuration in general is available.
 	HaveLua() bool
 
+	// HaveLuaBackend returns a boolean indicating whether a Lua backend is available in the current configuration.
+	HaveLuaBackend() bool
+
 	// GetLuaInitScriptPath returns the path to the Lua initialization script.
 	GetLuaInitScriptPath() string
 
@@ -952,6 +955,21 @@ func (f *FileSettings) HaveLua() bool {
 	}
 
 	return f.Lua != nil
+}
+
+// HaveLuaBackend checks if the FileSettings instance has a Lua backend configured and returns true if found, otherwise false.
+func (f *FileSettings) HaveLuaBackend() bool {
+	if f == nil {
+		return false
+	}
+
+	for _, backendType := range f.Server.Backends {
+		if backendType.Get() == definitions.BackendLua {
+			return true
+		}
+	}
+
+	return false
 }
 
 // HaveLDAPBackend checks if the configuration includes an LDAP backend and returns true if it exists, otherwise false.

--- a/server/server.go
+++ b/server/server.go
@@ -940,12 +940,7 @@ func initializeMLMetrics(ctx context.Context) {
 			definitions.LogKeyMsg, "Failed to initialize ML system",
 			definitions.LogKeyMsg, err,
 		)
-	} else {
-		level.Info(log.Logger).Log(
-			definitions.LogKeyMsg, "ML system initialized successfully",
-		)
 	}
-
 }
 
 // runConnectionManager initializes the ConnectionManager, registers the server address, and starts a ticker to update connection counts.

--- a/vendor/github.com/gabriel-vasile/mimetype/.golangci.yml
+++ b/vendor/github.com/gabriel-vasile/mimetype/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  exclusions:
+    presets:
+      - std-error-handling

--- a/vendor/github.com/gabriel-vasile/mimetype/internal/json/parser.go
+++ b/vendor/github.com/gabriel-vasile/mimetype/internal/json/parser.go
@@ -1,0 +1,464 @@
+package json
+
+import (
+	"bytes"
+	"sync"
+)
+
+const (
+	QueryNone    = "json"
+	QueryGeo     = "geo"
+	QueryHAR     = "har"
+	QueryGLTF    = "gltf"
+	maxRecursion = 4096
+)
+
+var queries = map[string][]query{
+	QueryNone: nil,
+	QueryGeo: {{
+		SearchPath: [][]byte{[]byte("type")},
+		SearchVals: [][]byte{
+			[]byte(`"Feature"`),
+			[]byte(`"FeatureCollection"`),
+			[]byte(`"Point"`),
+			[]byte(`"LineString"`),
+			[]byte(`"Polygon"`),
+			[]byte(`"MultiPoint"`),
+			[]byte(`"MultiLineString"`),
+			[]byte(`"MultiPolygon"`),
+			[]byte(`"GeometryCollection"`),
+		},
+	}},
+	QueryHAR: {{
+		SearchPath: [][]byte{[]byte("log"), []byte("version")},
+	}, {
+		SearchPath: [][]byte{[]byte("log"), []byte("creator")},
+	}, {
+		SearchPath: [][]byte{[]byte("log"), []byte("entries")},
+	}},
+	QueryGLTF: {{
+		SearchPath: [][]byte{[]byte("asset"), []byte("version")},
+		SearchVals: [][]byte{[]byte(`"1.0"`), []byte(`"2.0"`)},
+	}},
+}
+
+var parserPool = sync.Pool{
+	New: func() any {
+		return &parserState{maxRecursion: maxRecursion}
+	},
+}
+
+// parserState holds the state of JSON parsing. The number of inspected bytes,
+// the current path inside the JSON object, etc.
+type parserState struct {
+	// ib represents the number of inspected bytes.
+	// Because mimetype limits itself to only reading the header of the file,
+	// it means sometimes the input JSON can be truncated. In that case, we want
+	// to still detect it as JSON, even if it's invalid/truncated.
+	// When ib == len(input) it means the JSON was valid (at least the header).
+	ib           int
+	maxRecursion int
+	// currPath keeps a track of the JSON keys parsed up.
+	// It works only for JSON objects. JSON arrays are ignored
+	// mainly because the functionality is not needed.
+	currPath [][]byte
+	// firstToken stores the first JSON token encountered in input.
+	// TODO: performance would be better if we would stop parsing as soon
+	// as we see that first token is not what we are interested in.
+	firstToken int
+	// querySatisfied is true if both path and value of any queries passed to
+	// consumeAny are satisfied.
+	querySatisfied bool
+}
+
+// query holds information about a combination of {"key": "val"} that we're trying
+// to search for inside the JSON.
+type query struct {
+	// SearchPath represents the whole path to look for inside the JSON.
+	// ex: [][]byte{[]byte("foo"), []byte("bar")} matches {"foo": {"bar": "baz"}}
+	SearchPath [][]byte
+	// SearchVals represents values to look for when the SearchPath is found.
+	// Each SearchVal element is tried until one of them matches (logical OR.)
+	SearchVals [][]byte
+}
+
+func eq(path1, path2 [][]byte) bool {
+	if len(path1) != len(path2) {
+		return false
+	}
+	for i := range path1 {
+		if !bytes.Equal(path1[i], path2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// LooksLikeObjectOrArray reports if first non white space character from raw
+// is either { or [. Parsing raw as JSON is a heavy operation. When receiving some
+// text input we can skip parsing if the input does not even look like JSON.
+func LooksLikeObjectOrArray(raw []byte) bool {
+	for i := range raw {
+		if isSpace(raw[i]) {
+			continue
+		}
+		return raw[i] == '{' || raw[i] == '['
+	}
+
+	return false
+}
+
+// Parse will take out a parser from the pool depending on queryType and tries
+// to parse raw bytes as JSON.
+func Parse(queryType string, raw []byte) (parsed, inspected, firstToken int, querySatisfied bool) {
+	p := parserPool.Get().(*parserState)
+	defer func() {
+		// Avoid hanging on to too much memory in extreme input cases.
+		if len(p.currPath) > 128 {
+			p.currPath = nil
+		}
+		parserPool.Put(p)
+	}()
+	p.reset()
+
+	qs := queries[queryType]
+	got := p.consumeAny(raw, qs, 0)
+	return got, p.ib, p.firstToken, p.querySatisfied
+}
+
+func (p *parserState) reset() {
+	p.ib = 0
+	p.currPath = p.currPath[0:0]
+	p.firstToken = TokInvalid
+	p.querySatisfied = false
+}
+
+func (p *parserState) consumeSpace(b []byte) (n int) {
+	for len(b) > 0 && isSpace(b[0]) {
+		b = b[1:]
+		n++
+		p.ib++
+	}
+	return n
+}
+
+func (p *parserState) consumeConst(b, cnst []byte) int {
+	lb := len(b)
+	for i, c := range cnst {
+		if lb > i && b[i] == c {
+			p.ib++
+		} else {
+			return 0
+		}
+	}
+	return len(cnst)
+}
+
+func (p *parserState) consumeString(b []byte) (n int) {
+	var c byte
+	for len(b[n:]) > 0 {
+		c, n = b[n], n+1
+		p.ib++
+		switch c {
+		case '\\':
+			if len(b[n:]) == 0 {
+				return 0
+			}
+			switch b[n] {
+			case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+				n++
+				p.ib++
+				continue
+			case 'u':
+				n++
+				p.ib++
+				for j := 0; j < 4 && len(b[n:]) > 0; j++ {
+					if !isXDigit(b[n]) {
+						return 0
+					}
+					n++
+					p.ib++
+				}
+				continue
+			default:
+				return 0
+			}
+		case '"':
+			return n
+		default:
+			continue
+		}
+	}
+	return 0
+}
+
+func (p *parserState) consumeNumber(b []byte) (n int) {
+	got := false
+	var i int
+
+	if len(b) == 0 {
+		goto out
+	}
+	if b[0] == '-' {
+		b, i = b[1:], i+1
+		p.ib++
+	}
+
+	for len(b) > 0 {
+		if !isDigit(b[0]) {
+			break
+		}
+		got = true
+		b, i = b[1:], i+1
+		p.ib++
+	}
+	if len(b) == 0 {
+		goto out
+	}
+	if b[0] == '.' {
+		b, i = b[1:], i+1
+		p.ib++
+	}
+	for len(b) > 0 {
+		if !isDigit(b[0]) {
+			break
+		}
+		got = true
+		b, i = b[1:], i+1
+		p.ib++
+	}
+	if len(b) == 0 {
+		goto out
+	}
+	if got && (b[0] == 'e' || b[0] == 'E') {
+		b, i = b[1:], i+1
+		p.ib++
+		got = false
+		if len(b) == 0 {
+			goto out
+		}
+		if b[0] == '+' || b[0] == '-' {
+			b, i = b[1:], i+1
+			p.ib++
+		}
+		for len(b) > 0 {
+			if !isDigit(b[0]) {
+				break
+			}
+			got = true
+			b, i = b[1:], i+1
+			p.ib++
+		}
+	}
+out:
+	if got {
+		return i
+	}
+	return 0
+}
+
+func (p *parserState) consumeArray(b []byte, qs []query, lvl int) (n int) {
+	p.currPath = append(p.currPath, []byte{'['})
+	if len(b) == 0 {
+		return 0
+	}
+
+	for n < len(b) {
+		n += p.consumeSpace(b[n:])
+		if len(b[n:]) == 0 {
+			return 0
+		}
+		if b[n] == ']' {
+			p.ib++
+			p.currPath = p.currPath[:len(p.currPath)-1]
+			return n + 1
+		}
+		innerParsed := p.consumeAny(b[n:], qs, lvl)
+		if innerParsed == 0 {
+			return 0
+		}
+		n += innerParsed
+		if len(b[n:]) == 0 {
+			return 0
+		}
+		switch b[n] {
+		case ',':
+			n += 1
+			p.ib++
+			continue
+		case ']':
+			p.ib++
+			return n + 1
+		default:
+			return 0
+		}
+	}
+	return 0
+}
+
+func queryPathMatch(qs []query, path [][]byte) int {
+	for i := range qs {
+		if eq(qs[i].SearchPath, path) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p *parserState) consumeObject(b []byte, qs []query, lvl int) (n int) {
+	for n < len(b) {
+		n += p.consumeSpace(b[n:])
+		if len(b[n:]) == 0 {
+			return 0
+		}
+		if b[n] == '}' {
+			p.ib++
+			return n + 1
+		}
+		if b[n] != '"' {
+			return 0
+		} else {
+			n += 1
+			p.ib++
+		}
+		// queryMatched stores the index of the query satisfying the current path.
+		queryMatched := -1
+		if keyLen := p.consumeString(b[n:]); keyLen == 0 {
+			return 0
+		} else {
+			p.currPath = append(p.currPath, b[n:n+keyLen-1])
+			if !p.querySatisfied {
+				queryMatched = queryPathMatch(qs, p.currPath)
+			}
+			n += keyLen
+		}
+		n += p.consumeSpace(b[n:])
+		if len(b[n:]) == 0 {
+			return 0
+		}
+		if b[n] != ':' {
+			return 0
+		} else {
+			n += 1
+			p.ib++
+		}
+		n += p.consumeSpace(b[n:])
+		if len(b[n:]) == 0 {
+			return 0
+		}
+
+		if valLen := p.consumeAny(b[n:], qs, lvl); valLen == 0 {
+			return 0
+		} else {
+			if queryMatched != -1 {
+				q := qs[queryMatched]
+				if len(q.SearchVals) == 0 {
+					p.querySatisfied = true
+				}
+				for _, val := range q.SearchVals {
+					if bytes.Equal(val, bytes.TrimSpace(b[n:n+valLen])) {
+						p.querySatisfied = true
+					}
+				}
+			}
+			n += valLen
+		}
+		if len(b[n:]) == 0 {
+			return 0
+		}
+		switch b[n] {
+		case ',':
+			p.currPath = p.currPath[:len(p.currPath)-1]
+			n++
+			p.ib++
+			continue
+		case '}':
+			p.currPath = p.currPath[:len(p.currPath)-1]
+			p.ib++
+			return n + 1
+		default:
+			return 0
+		}
+	}
+	return 0
+}
+
+func (p *parserState) consumeAny(b []byte, qs []query, lvl int) (n int) {
+	// Avoid too much recursion.
+	if p.maxRecursion != 0 && lvl > p.maxRecursion {
+		return 0
+	}
+	n += p.consumeSpace(b)
+	if len(b[n:]) == 0 {
+		return 0
+	}
+
+	var t, rv int
+	switch b[n] {
+	case '"':
+		n++
+		p.ib++
+		rv = p.consumeString(b[n:])
+		t = TokString
+	case '[':
+		n++
+		p.ib++
+		rv = p.consumeArray(b[n:], qs, lvl+1)
+		t = TokArray
+	case '{':
+		n++
+		p.ib++
+		rv = p.consumeObject(b[n:], qs, lvl+1)
+		t = TokObject
+	case 't':
+		rv = p.consumeConst(b[n:], []byte("true"))
+		t = TokTrue
+	case 'f':
+		rv = p.consumeConst(b[n:], []byte("false"))
+		t = TokFalse
+	case 'n':
+		rv = p.consumeConst(b[n:], []byte("null"))
+		t = TokNull
+	default:
+		rv = p.consumeNumber(b[n:])
+		t = TokNumber
+	}
+	if lvl == 0 {
+		p.firstToken = t
+	}
+	if len(qs) == 0 {
+		p.querySatisfied = true
+	}
+	if rv <= 0 {
+		return n
+	}
+	n += rv
+	n += p.consumeSpace(b[n:])
+	return n
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+func isDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}
+
+func isXDigit(c byte) bool {
+	if isDigit(c) {
+		return true
+	}
+	return ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')
+}
+
+const (
+	TokInvalid = 0
+	TokNull    = 1 << iota
+	TokTrue
+	TokFalse
+	TokNumber
+	TokString
+	TokArray
+	TokObject
+	TokComma
+)

--- a/vendor/github.com/quic-go/quic-go/path_manager_outgoing.go
+++ b/vendor/github.com/quic-go/quic-go/path_manager_outgoing.go
@@ -1,0 +1,311 @@
+package quic
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/wire"
+)
+
+var (
+	// ErrPathClosed is returned when trying to switch to a path that has been closed.
+	ErrPathClosed = errors.New("path closed")
+	// ErrPathNotValidated is returned when trying to use a path before path probing has completed.
+	ErrPathNotValidated = errors.New("path not yet validated")
+)
+
+var errPathDoesNotExist = errors.New("path does not exist")
+
+// Path is a network path.
+type Path struct {
+	id          pathID
+	pathManager *pathManagerOutgoing
+	tr          *Transport
+	initialRTT  time.Duration
+
+	enablePath func()
+	validated  atomic.Bool
+	abandon    chan struct{}
+}
+
+func (p *Path) Probe(ctx context.Context) error {
+	path := p.pathManager.addPath(p, p.enablePath)
+
+	p.pathManager.enqueueProbe(p)
+	nextProbeDur := p.initialRTT
+	var timer *time.Timer
+	var timerChan <-chan time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-path.Validated():
+			p.validated.Store(true)
+			return nil
+		case <-timerChan:
+			p.pathManager.enqueueProbe(p)
+		case <-path.ProbeSent():
+		case <-p.abandon:
+			return ErrPathClosed
+		}
+
+		if timer != nil {
+			timer.Stop()
+		}
+		timer = time.NewTimer(nextProbeDur)
+		timerChan = timer.C
+		nextProbeDur *= 2 // exponential backoff
+	}
+}
+
+// Switch switches the QUIC connection to this path.
+// It immediately stops sending on the old path, and sends on this new path.
+func (p *Path) Switch() error {
+	if err := p.pathManager.switchToPath(p.id); err != nil {
+		switch {
+		case errors.Is(err, ErrPathNotValidated):
+			return err
+		case errors.Is(err, errPathDoesNotExist) && !p.validated.Load():
+			select {
+			case <-p.abandon:
+				return ErrPathClosed
+			default:
+				return ErrPathNotValidated
+			}
+		default:
+			return ErrPathClosed
+		}
+	}
+	return nil
+}
+
+// Close abandons a path.
+// It is not possible to close the path that’s currently active.
+// After closing, it is not possible to probe this path again.
+func (p *Path) Close() error {
+	select {
+	case <-p.abandon:
+		return nil
+	default:
+	}
+
+	if err := p.pathManager.removePath(p.id); err != nil {
+		return err
+	}
+	close(p.abandon)
+	return nil
+}
+
+type pathOutgoing struct {
+	pathChallenges [][8]byte // length is implicitly limited by exponential backoff
+	tr             *Transport
+	isValidated    bool
+	probeSent      chan struct{} // receives when a PATH_CHALLENGE is sent
+	validated      chan struct{} // closed when the path the corresponding PATH_RESPONSE is received
+	enablePath     func()
+}
+
+func (p *pathOutgoing) ProbeSent() <-chan struct{} { return p.probeSent }
+func (p *pathOutgoing) Validated() <-chan struct{} { return p.validated }
+
+type pathManagerOutgoing struct {
+	getConnID       func(pathID) (_ protocol.ConnectionID, ok bool)
+	retireConnID    func(pathID)
+	scheduleSending func()
+
+	mx             sync.Mutex
+	activePath     pathID
+	pathsToProbe   []pathID
+	paths          map[pathID]*pathOutgoing
+	nextPathID     pathID
+	pathToSwitchTo *pathOutgoing
+}
+
+func newPathManagerOutgoing(
+	getConnID func(pathID) (_ protocol.ConnectionID, ok bool),
+	retireConnID func(pathID),
+	scheduleSending func(),
+) *pathManagerOutgoing {
+	return &pathManagerOutgoing{
+		activePath:      0, // at initialization time, we're guaranteed to be using the handshake path
+		nextPathID:      1,
+		getConnID:       getConnID,
+		retireConnID:    retireConnID,
+		scheduleSending: scheduleSending,
+		paths:           make(map[pathID]*pathOutgoing, 4),
+	}
+}
+
+func (pm *pathManagerOutgoing) addPath(p *Path, enablePath func()) *pathOutgoing {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	// path might already exist, and just being re-probed
+	if existingPath, ok := pm.paths[p.id]; ok {
+		existingPath.validated = make(chan struct{})
+		return existingPath
+	}
+
+	path := &pathOutgoing{
+		tr:         p.tr,
+		probeSent:  make(chan struct{}, 1),
+		validated:  make(chan struct{}),
+		enablePath: enablePath,
+	}
+	pm.paths[p.id] = path
+	return path
+}
+
+func (pm *pathManagerOutgoing) enqueueProbe(p *Path) {
+	pm.mx.Lock()
+	pm.pathsToProbe = append(pm.pathsToProbe, p.id)
+	pm.mx.Unlock()
+	pm.scheduleSending()
+}
+
+func (pm *pathManagerOutgoing) removePath(id pathID) error {
+	if err := pm.removePathImpl(id); err != nil {
+		return err
+	}
+	pm.scheduleSending()
+	return nil
+}
+
+func (pm *pathManagerOutgoing) removePathImpl(id pathID) error {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	if id == pm.activePath {
+		return errors.New("cannot close active path")
+	}
+	p, ok := pm.paths[id]
+	if !ok {
+		return nil
+	}
+	if len(p.pathChallenges) > 0 {
+		pm.retireConnID(id)
+	}
+	delete(pm.paths, id)
+	return nil
+}
+
+func (pm *pathManagerOutgoing) switchToPath(id pathID) error {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	p, ok := pm.paths[id]
+	if !ok {
+		return errPathDoesNotExist
+	}
+	if !p.isValidated {
+		return ErrPathNotValidated
+	}
+	pm.pathToSwitchTo = p
+	pm.activePath = id
+	return nil
+}
+
+func (pm *pathManagerOutgoing) NewPath(t *Transport, initialRTT time.Duration, enablePath func()) *Path {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	id := pm.nextPathID
+	pm.nextPathID++
+	return &Path{
+		pathManager: pm,
+		id:          id,
+		tr:          t,
+		enablePath:  enablePath,
+		initialRTT:  initialRTT,
+		abandon:     make(chan struct{}),
+	}
+}
+
+func (pm *pathManagerOutgoing) NextPathToProbe() (_ protocol.ConnectionID, _ ackhandler.Frame, _ *Transport, hasPath bool) {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	var p *pathOutgoing
+	id := invalidPathID
+	for _, pID := range pm.pathsToProbe {
+		var ok bool
+		p, ok = pm.paths[pID]
+		if ok {
+			id = pID
+			break
+		}
+		// if the path doesn't exist in the map, it might have been abandoned
+		pm.pathsToProbe = pm.pathsToProbe[1:]
+	}
+	if id == invalidPathID {
+		return protocol.ConnectionID{}, ackhandler.Frame{}, nil, false
+	}
+
+	connID, ok := pm.getConnID(id)
+	if !ok {
+		return protocol.ConnectionID{}, ackhandler.Frame{}, nil, false
+	}
+
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	p.pathChallenges = append(p.pathChallenges, b)
+
+	pm.pathsToProbe = pm.pathsToProbe[1:]
+	p.enablePath()
+	select {
+	case p.probeSent <- struct{}{}:
+	default:
+	}
+	frame := ackhandler.Frame{
+		Frame:   &wire.PathChallengeFrame{Data: b},
+		Handler: (*pathManagerOutgoingAckHandler)(pm),
+	}
+	return connID, frame, p.tr, true
+}
+
+func (pm *pathManagerOutgoing) HandlePathResponseFrame(f *wire.PathResponseFrame) {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	for _, p := range pm.paths {
+		if slices.Contains(p.pathChallenges, f.Data) {
+			// path validated
+			if !p.isValidated {
+				// make sure that duplicate PATH_RESPONSE frames are ignored
+				p.isValidated = true
+				p.pathChallenges = nil
+				close(p.validated)
+			}
+			break
+		}
+	}
+}
+
+func (pm *pathManagerOutgoing) ShouldSwitchPath() (*Transport, bool) {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	if pm.pathToSwitchTo == nil {
+		return nil, false
+	}
+	p := pm.pathToSwitchTo
+	pm.pathToSwitchTo = nil
+	return p.tr, true
+}
+
+type pathManagerOutgoingAckHandler pathManagerOutgoing
+
+var _ ackhandler.FrameHandler = &pathManagerOutgoingAckHandler{}
+
+// OnAcked is called when the PATH_CHALLENGE is acked.
+// This doesn't validate the path, only receiving the PATH_RESPONSE does.
+func (pm *pathManagerOutgoingAckHandler) OnAcked(wire.Frame) {}
+
+func (pm *pathManagerOutgoingAckHandler) OnLost(wire.Frame) {}

--- a/vendor/github.com/redis/go-redis/v9/RELEASE-NOTES.md
+++ b/vendor/github.com/redis/go-redis/v9/RELEASE-NOTES.md
@@ -1,0 +1,80 @@
+# Release Notes
+
+# 9.8.0 (2025-04-30)
+
+## 🚀 Highlights
+- **Redis 8 Support**: Full compatibility with Redis 8.0, including testing and CI integration
+- **Enhanced Hash Operations**: Added support for new hash commands (`HGETDEL`, `HGETEX`, `HSETEX`) and `HSTRLEN` command
+- **Search Improvements**: Enabled Search DIALECT 2 by default and added `CountOnly` argument for `FT.Search`
+
+## ✨ New Features
+- Added support for new hash commands: `HGETDEL`, `HGETEX`, `HSETEX` ([#3305](https://github.com/redis/go-redis/pull/3305))
+- Added `HSTRLEN` command for hash operations ([#2843](https://github.com/redis/go-redis/pull/2843))
+- Added `Do` method for raw query by single connection from `pool.Conn()` ([#3182](https://github.com/redis/go-redis/pull/3182))
+- Prevent false-positive marshaling by treating zero time.Time as empty in isEmptyValue ([#3273](https://github.com/redis/go-redis/pull/3273))
+- Added FailoverClusterClient support for Universal client ([#2794](https://github.com/redis/go-redis/pull/2794))
+- Added support for cluster mode with `IsClusterMode` config parameter ([#3255](https://github.com/redis/go-redis/pull/3255))
+- Added client name support in `HELLO` RESP handshake ([#3294](https://github.com/redis/go-redis/pull/3294))
+- **Enabled Search DIALECT 2 by default** ([#3213](https://github.com/redis/go-redis/pull/3213))
+- Added read-only option for failover configurations ([#3281](https://github.com/redis/go-redis/pull/3281))
+- Added `CountOnly` argument for `FT.Search` to use `LIMIT 0 0` ([#3338](https://github.com/redis/go-redis/pull/3338))
+- Added `DB` option support in `NewFailoverClusterClient` ([#3342](https://github.com/redis/go-redis/pull/3342))
+- Added `nil` check for the options when creating a client ([#3363](https://github.com/redis/go-redis/pull/3363))
+
+## 🐛 Bug Fixes
+- Fixed `PubSub` concurrency safety issues ([#3360](https://github.com/redis/go-redis/pull/3360))
+- Fixed panic caused when argument is `nil` ([#3353](https://github.com/redis/go-redis/pull/3353))
+- Improved error handling when fetching master node from sentinels ([#3349](https://github.com/redis/go-redis/pull/3349))
+- Fixed connection pool timeout issues and increased retries ([#3298](https://github.com/redis/go-redis/pull/3298))
+- Fixed context cancellation error leading to connection spikes on Primary instances ([#3190](https://github.com/redis/go-redis/pull/3190))
+- Fixed RedisCluster client to consider `MASTERDOWN` a retriable error ([#3164](https://github.com/redis/go-redis/pull/3164))
+- Fixed tracing to show complete commands instead of truncated versions ([#3290](https://github.com/redis/go-redis/pull/3290))
+- Fixed OpenTelemetry instrumentation to prevent multiple span reporting ([#3168](https://github.com/redis/go-redis/pull/3168))
+- Fixed `FT.Search` Limit argument and added `CountOnly` argument for limit 0 0 ([#3338](https://github.com/redis/go-redis/pull/3338))
+- Fixed missing command in interface ([#3344](https://github.com/redis/go-redis/pull/3344))
+- Fixed slot calculation for `COUNTKEYSINSLOT` command ([#3327](https://github.com/redis/go-redis/pull/3327))
+- Updated PubSub implementation with correct context ([#3329](https://github.com/redis/go-redis/pull/3329))
+
+## 📚 Documentation
+- Added hash search examples ([#3357](https://github.com/redis/go-redis/pull/3357))
+- Fixed documentation comments ([#3351](https://github.com/redis/go-redis/pull/3351))
+- Added `CountOnly` search example ([#3345](https://github.com/redis/go-redis/pull/3345))
+- Added examples for list commands: `LLEN`, `LPOP`, `LPUSH`, `LRANGE`, `RPOP`, `RPUSH` ([#3234](https://github.com/redis/go-redis/pull/3234))
+- Added `SADD` and `SMEMBERS` command examples ([#3242](https://github.com/redis/go-redis/pull/3242))
+- Updated `README.md` to use Redis Discord guild ([#3331](https://github.com/redis/go-redis/pull/3331))
+- Updated `HExpire` command documentation ([#3355](https://github.com/redis/go-redis/pull/3355))
+- Featured OpenTelemetry instrumentation more prominently ([#3316](https://github.com/redis/go-redis/pull/3316))
+- Updated `README.md` with additional information ([#310ce55](https://github.com/redis/go-redis/commit/310ce55))
+
+## ⚡ Performance and Reliability
+- Bound connection pool background dials to configured dial timeout ([#3089](https://github.com/redis/go-redis/pull/3089))
+- Ensured context isn't exhausted via concurrent query ([#3334](https://github.com/redis/go-redis/pull/3334))
+
+## 🔧 Dependencies and Infrastructure
+- Updated testing image to Redis 8.0-RC2 ([#3361](https://github.com/redis/go-redis/pull/3361))
+- Enabled CI for Redis CE 8.0 ([#3274](https://github.com/redis/go-redis/pull/3274))
+- Updated various dependencies:
+  - Bumped golangci/golangci-lint-action from 6.5.0 to 7.0.0 ([#3354](https://github.com/redis/go-redis/pull/3354))
+  - Bumped rojopolis/spellcheck-github-actions ([#3336](https://github.com/redis/go-redis/pull/3336))
+  - Bumped golang.org/x/net in example/otel ([#3308](https://github.com/redis/go-redis/pull/3308))
+- Migrated golangci-lint configuration to v2 format ([#3354](https://github.com/redis/go-redis/pull/3354))
+
+## ⚠️ Breaking Changes
+- **Enabled Search DIALECT 2 by default** ([#3213](https://github.com/redis/go-redis/pull/3213))
+- Dropped RedisGears (Triggers and Functions) support ([#3321](https://github.com/redis/go-redis/pull/3321))
+- Dropped FT.PROFILE command that was never enabled ([#3323](https://github.com/redis/go-redis/pull/3323))
+
+## 🔒 Security
+- Fixed network error handling on SETINFO (CVE-2025-29923) ([#3295](https://github.com/redis/go-redis/pull/3295))
+
+## 🧪 Testing
+- Added integration tests for Redis 8 behavior changes in Redis Search ([#3337](https://github.com/redis/go-redis/pull/3337))
+- Added vector types INT8 and UINT8 tests ([#3299](https://github.com/redis/go-redis/pull/3299))
+- Added test codes for search_commands.go ([#3285](https://github.com/redis/go-redis/pull/3285))
+- Fixed example test sorting ([#3292](https://github.com/redis/go-redis/pull/3292))
+
+## 👥 Contributors
+
+We would like to thank all the contributors who made this release possible:
+
+[@alexander-menshchikov](https://github.com/alexander-menshchikov), [@EXPEbdodla](https://github.com/EXPEbdodla), [@afti](https://github.com/afti), [@dmaier-redislabs](https://github.com/dmaier-redislabs), [@four_leaf_clover](https://github.com/four_leaf_clover), [@alohaglenn](https://github.com/alohaglenn), [@gh73962](https://github.com/gh73962), [@justinmir](https://github.com/justinmir), [@LINKIWI](https://github.com/LINKIWI), [@liushuangbill](https://github.com/liushuangbill), [@golang88](https://github.com/golang88), [@gnpaone](https://github.com/gnpaone), [@ndyakov](https://github.com/ndyakov), [@nikolaydubina](https://github.com/nikolaydubina), [@oleglacto](https://github.com/oleglacto), [@andy-stark-redis](https://github.com/andy-stark-redis), [@rodneyosodo](https://github.com/rodneyosodo), [@dependabot](https://github.com/dependabot), [@rfyiamcool](https://github.com/rfyiamcool), [@frankxjkuang](https://github.com/frankxjkuang), [@fukua95](https://github.com/fukua95), [@soleymani-milad](https://github.com/soleymani-milad), [@ofekshenawa](https://github.com/ofekshenawa), [@khasanovbi](https://github.com/khasanovbi)

--- a/vendor/github.com/redis/go-redis/v9/docker-compose.yml
+++ b/vendor/github.com/redis/go-redis/v9/docker-compose.yml
@@ -1,0 +1,106 @@
+---
+
+services:
+  redis:
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:rs-7.4.0-v2}
+    platform: linux/amd64
+    container_name: redis-standalone
+    environment:
+      - TLS_ENABLED=yes
+      - REDIS_CLUSTER=no
+      - PORT=6379
+      - TLS_PORT=6666
+    command: ${REDIS_EXTRA_ARGS:---enable-debug-command yes --enable-module-command yes --tls-auth-clients optional --save ""}
+    ports:
+      - 6379:6379
+      - 6666:6666 # TLS port
+    volumes:
+      - "./dockers/standalone:/redis/work"
+    profiles:
+      - standalone
+      - sentinel
+      - all-stack
+      - all
+
+  osscluster:
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:rs-7.4.0-v2}
+    platform: linux/amd64
+    container_name: redis-osscluster
+    environment:
+      - NODES=6
+      - PORT=16600
+    command: "--cluster-enabled yes"
+    ports:
+      - "16600-16605:16600-16605"
+    volumes:
+      - "./dockers/osscluster:/redis/work"
+    profiles:
+      - cluster
+      - all-stack
+      - all
+
+  sentinel-cluster:
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:rs-7.4.0-v2}
+    platform: linux/amd64
+    container_name: redis-sentinel-cluster
+    network_mode: "host"
+    environment:
+      - NODES=3
+      - TLS_ENABLED=yes
+      - REDIS_CLUSTER=no
+      - PORT=9121
+    command: ${REDIS_EXTRA_ARGS:---enable-debug-command yes --enable-module-command yes --tls-auth-clients optional --save ""}
+    #ports:
+    #  - "9121-9123:9121-9123"
+    volumes:
+      - "./dockers/sentinel-cluster:/redis/work"
+    profiles:
+      - sentinel
+      - all-stack
+      - all
+
+  sentinel:
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:rs-7.4.0-v2}
+    platform: linux/amd64
+    container_name: redis-sentinel
+    depends_on:
+      - sentinel-cluster
+    environment:
+      - NODES=3
+      - REDIS_CLUSTER=no
+      - PORT=26379
+    command: ${REDIS_EXTRA_ARGS:---sentinel}
+    network_mode: "host"
+    #ports:
+    #  - 26379:26379
+    #  - 26380:26380
+    #  - 26381:26381
+    volumes:
+      - "./dockers/sentinel.conf:/redis/config-default/redis.conf"
+      - "./dockers/sentinel:/redis/work"
+    profiles:
+      - sentinel
+      - all-stack
+      - all
+
+  ring-cluster:
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:rs-7.4.0-v2}
+    platform: linux/amd64
+    container_name: redis-ring-cluster
+    environment:
+      - NODES=3
+      - TLS_ENABLED=yes
+      - REDIS_CLUSTER=no
+      - PORT=6390
+    command: ${REDIS_EXTRA_ARGS:---enable-debug-command yes --enable-module-command yes --tls-auth-clients optional --save ""}
+    ports:
+      - 6390:6390
+      - 6391:6391
+      - 6392:6392
+    volumes:
+      - "./dockers/ring:/redis/work"
+    profiles:
+      - ring
+      - cluster
+      - all-stack
+      - all

--- a/vendor/github.com/spf13/cast/.editorconfig
+++ b/vendor/github.com/spf13/cast/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/vendor/github.com/spf13/cast/.golangci.yaml
+++ b/vendor/github.com/spf13/cast/.golangci.yaml
@@ -1,0 +1,39 @@
+version: "2"
+
+run:
+  timeout: 10m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    # - revive
+    - unused
+
+  disable:
+    - staticcheck
+
+  settings:
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false # report any unused nolint directives
+      require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    # - gofumpt
+    - goimports
+    # - golines
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule


### PR DESCRIPTION
The creation of LDAP and Lua backends now checks if they are enabled in the configuration before initializing them. This prevents unnecessary backend initialization when the corresponding backends are not configured, improving efficiency and clarity. Additionally, a new configuration helper, `HaveLuaBackend`, has been introduced to support this logic.