### PR TITLE
Feat: Add protocol-specific brute force rule support

### DIFF
--- a/server/config/bruteforce.go
+++ b/server/config/bruteforce.go
@@ -110,7 +110,8 @@ type BruteForceRule struct {
 	CIDR           uint          `mapstructure:"cidr" validate:"required,min=1,max=128"`
 	IPv4           bool
 	IPv6           bool
-	FailedRequests uint `mapstructure:"failed_requests" validate:"required,min=1"`
+	FailedRequests uint     `mapstructure:"failed_requests" validate:"required,min=1"`
+	OnlyProtocols  []string `mapstructure:"only_protocols" validate:"omitempty"`
 }
 
 func (b *BruteForceRule) String() string {

--- a/server/core/bruteforce.go
+++ b/server/core/bruteforce.go
@@ -289,6 +289,11 @@ func (a *AuthState) CheckBruteForce() (blockClientIP bool) {
 		bm = bruteforce.NewBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP)
 	}
 
+	// Set the protocol on the bucket manager
+	if a.Protocol != nil && a.Protocol.Get() != "" {
+		bm = bm.WithProtocol(a.Protocol.Get())
+	}
+
 	defer func() {
 		if mlBM, ok := bm.(*ml.MLBucketManager); ok {
 			mlBM.Close()
@@ -406,6 +411,11 @@ func (a *AuthState) UpdateBruteForceBucketsCounter() {
 			mlManager.SetNoAuth(a.NoAuth)
 		}
 
+		// Set the protocol if available
+		if a.Protocol != nil && a.Protocol.Get() != "" {
+			mlBM = mlBM.WithProtocol(a.Protocol.Get())
+		}
+
 		// Check if additional features are available from the Context
 		if a.Context != nil {
 			if features := lualib.GetAdditionalFeatures(a.HTTPClientContext); features != nil {
@@ -421,6 +431,11 @@ func (a *AuthState) UpdateBruteForceBucketsCounter() {
 		bm = mlBM
 	} else {
 		bm = bruteforce.NewBucketManager(a.HTTPClientContext, *a.GUID, a.ClientIP)
+
+		// Set the protocol if available
+		if a.Protocol != nil && a.Protocol.Get() != "" {
+			bm = bm.WithProtocol(a.Protocol.Get())
+		}
 	}
 
 	for _, rule := range config.GetFile().GetBruteForceRules() {


### PR DESCRIPTION
Introduce protocol-specific brute force rules, allowing differentiation of rules for distinct protocols (e.g., IMAP, SMTP). Updated Redis key structure, added protocol checks in rule validation, and extended the REST API for protocol handling. Documentation updated accordingly.