### PR TITLE
Feat: Add OIDC Client ID to logging metadata

### DIFF
--- a/server/core/auth.go
+++ b/server/core/auth.go
@@ -997,6 +997,7 @@ func (a *AuthState) LogLineTemplate(status string, endpoint string) []any {
 		definitions.LogKeyMode, mode,
 		definitions.LogKeyBackendName, backendName,
 		definitions.LogKeyProtocol, util.WithNotAvailable(a.Protocol.String()),
+		definitions.LogKeyOIDCCID, util.WithNotAvailable(a.OIDCCID),
 		definitions.LogKeyLocalIP, util.WithNotAvailable(a.XLocalIP),
 		definitions.LogKeyPort, util.WithNotAvailable(a.XPort),
 		definitions.LogKeyClientIP, util.WithNotAvailable(a.ClientIP),

--- a/server/definitions/const.go
+++ b/server/definitions/const.go
@@ -33,6 +33,9 @@ const (
 	// LogKeyProtocol represents the network protocol used, logged in log entries.
 	LogKeyProtocol = "protocol"
 
+	// LogKeyOIDCCID represents the log key for OpenID Connect Client ID.
+	LogKeyOIDCCID = "oidc_cid"
+
 	// LogKeyLocalIP represents the local IP address, logged in log entries.
 	LogKeyLocalIP = "local_ip"
 


### PR DESCRIPTION
Include OIDC Client ID in log entries to enhance traceability and debug capability. Updated constants ensure consistent key management for logging purposes.