### PR TITLE
Fix: Update nauthilus service path and add install/uninstall tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG_LIST := $(shell go list ./... | grep -v /vendor/)
 GIT_TAG=$(shell git describe --tags --abbrev=0)
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 
-.PHONY: all test race msan build clean
+.PHONY: all test race msan build clean install uninstall
 
 all: build
 
@@ -24,3 +24,17 @@ build:
 
 clean: ## Remove previous build
 	[ -x $(OUTPUT) ] && rm -f $(OUTPUT)
+
+install: build ## Install nauthilus binary and systemd service
+	install -D -m 755 $(OUTPUT) /usr/local/sbin/nauthilus
+	install -D -m 644 systemd/nauthilus.service /etc/systemd/system/nauthilus.service
+	@echo "Installed nauthilus binary to /usr/local/sbin/nauthilus"
+	@echo "Installed systemd service to /etc/systemd/system/nauthilus.service"
+	@echo "You may need to run 'systemctl daemon-reload' to use the service"
+
+uninstall: ## Uninstall nauthilus binary and systemd service
+	rm -f /usr/local/sbin/nauthilus
+	rm -f /etc/systemd/system/nauthilus.service
+	@echo "Removed nauthilus binary from /usr/local/sbin/nauthilus"
+	@echo "Removed systemd service from /etc/systemd/system/nauthilus.service"
+	@echo "You may need to run 'systemctl daemon-reload' to apply changes"

--- a/systemd/nauthilus.service
+++ b/systemd/nauthilus.service
@@ -7,10 +7,10 @@ Type=simple
 Restart=always
 DynamicUser=1
 EnvironmentFile=-/etc/default/nauthilus
-ExecStart=/usr/sbin/nauthilus
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=geoip-policyd
+ExecStart=/usr/local/sbin/nauthilus
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=nauthilus
 MemoryMax=150M
 CPUQuota=50%
 


### PR DESCRIPTION
Changed the execution path of nauthilus in the systemd service file to `/usr/local/sbin/nauthilus`. Added `install` and `uninstall` tasks in the Makefile to manage binary and service installation. Improved usability by providing relevant instructions post-installation/uninstallation.