### PR TITLE
Fix: Handle nil neural network config gracefully in brute force logic

### DIFF
--- a/contrib/Workshop_de.md
+++ b/contrib/Workshop_de.md
@@ -201,14 +201,14 @@ server:
   backends: [ cache, ldap, lua ]
   features: [ brute_force, tls_encryption, rbl, relay_domains, lua ]
 
-redis:
-  master:
-    address: "localhost:6379"
-  database_number: 0
-  prefix: nt_
-  pool_size: 10
-  positive_cache_ttl: 3600
-  negative_cache_ttl: 7200
+  redis:
+    master:
+      address: "localhost:6379"
+    database_number: 0
+    prefix: nt_
+    pool_size: 10
+    positive_cache_ttl: 3600
+    negative_cache_ttl: 7200
 
 ldap:
   config:

--- a/contrib/Workshop_en.md
+++ b/contrib/Workshop_en.md
@@ -201,14 +201,14 @@ server:
   backends: [ cache, ldap, lua ]
   features: [ brute_force, tls_encryption, rbl, relay_domains, lua ]
 
-redis:
-  master:
-    address: "localhost:6379"
-  database_number: 0
-  prefix: nt_
-  pool_size: 10
-  positive_cache_ttl: 3600
-  negative_cache_ttl: 7200
+  redis:
+    master:
+      address: "localhost:6379"
+    database_number: 0
+    prefix: nt_
+    pool_size: 10
+    positive_cache_ttl: 3600
+    negative_cache_ttl: 7200
 
 ldap:
   config:

--- a/server/bruteforce/ml/integration.go
+++ b/server/bruteforce/ml/integration.go
@@ -65,10 +65,17 @@ func NewMLBucketManager(ctx context.Context, guid, clientIP string) bruteforce.B
 		return standardBM
 	}
 
-	// Get weights and threshold from configuration
-	staticWeight := config.GetFile().GetBruteForce().GetNeuralNetwork().GetStaticWeight()
-	mlWeight := config.GetFile().GetBruteForce().GetNeuralNetwork().GetMLWeight()
-	threshold := config.GetFile().GetBruteForce().GetNeuralNetwork().GetThreshold()
+	// Get weights and threshold from configuration, handling nil case
+	staticWeight := 0.4 // Default static weight
+	mlWeight := 0.6     // Default ML weight
+	threshold := 0.7    // Default threshold
+
+	nnConfig := config.GetFile().GetBruteForce().GetNeuralNetwork()
+	if nnConfig != nil {
+		staticWeight = nnConfig.GetStaticWeight()
+		mlWeight = nnConfig.GetMLWeight()
+		threshold = nnConfig.GetThreshold()
+	}
 
 	// Create our ML-enhanced bucket manager
 	mlBM := &MLBucketManager{

--- a/server/config/bruteforce.go
+++ b/server/config/bruteforce.go
@@ -91,7 +91,12 @@ func (b *BruteForceSection) GetCustomTolerations() []Tolerate {
 }
 
 // GetNeuralNetwork retrieves a pointer to the NeuralNetwork configuration from the ServerSection instance.
+// Returns nil if the BruteForceSection is nil.
 func (s *BruteForceSection) GetNeuralNetwork() *NeuralNetwork {
+	if s == nil {
+		return nil
+	}
+
 	return &s.NeuralNetwork
 }
 


### PR DESCRIPTION
Added robust null checks for neural network configuration to prevent potential crashes in brute force modules. Defaults are applied when config values are missing, ensuring backward compatibility and reliable behavior.