### PR TITLE
Fix: Update binary installation path in build workflow

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -70,7 +70,7 @@ jobs:
           mkdir -p .debpkg/usr/local/sbin
           mkdir -p .debpkg/usr/lib/systemd/system
           mkdir -p .debpkg/usr/share/doc/${{ env.APP_NAME }}
-          cp server/${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} .debpkg/usr/sbin/${{ env.APP_NAME }}
+          cp server/${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} .debpkg/usr/local/sbin/${{ env.APP_NAME }}
           cp systemd/${{ env.APP_NAME }}.service .debpkg/usr/lib/systemd/system/
           cp LICENSE README.md NOTICE.md .debpkg/usr/share/doc/${{ env.APP_NAME }}/
 


### PR DESCRIPTION
Adjusted the binary installation path in `.github/workflows/build-stable.yaml` from `/usr/sbin` to `/usr/local/sbin` to align with filesystem standards.