### PR TITLE
Feat: Enhance TLS configuration with CA support and advanced options

### DIFF
--- a/server/util/util.go
+++ b/server/util/util.go
@@ -590,7 +590,7 @@ func NewHTTPClient() *http.Client {
 			MaxIdleConnsPerHost: config.GetFile().GetServer().GetHTTPClient().GetMaxIdleConnsPerHost(),
 			IdleConnTimeout:     config.GetFile().GetServer().GetHTTPClient().GetIdleConnTimeout(),
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: config.GetFile().GetServer().GetTLS().GetHTTPClientSkipVerify(),
+				InsecureSkipVerify: config.GetFile().GetServer().GetTLS().GetHTTPClientSkipVerify() || config.GetFile().GetServer().GetHTTPClient().GetTLS().GetSkipVerify(),
 			},
 		},
 	}


### PR DESCRIPTION
Added support for loading CA certificates, setting minimum TLS versions, and configuring cipher suites. Extended TLS configuration options to improve security and flexibility across Redis clients, HTTP clients, and server communications. Deprecated `HTTPClientSkipVerify` in favor of `SkipVerify`.