### PR TITLE
Refactor: Remove unnecessary colons from Redis key prefixes in brutef…

### DIFF
--- a/server/bruteforce/bruteforce_test.go
+++ b/server/bruteforce/bruteforce_test.go
@@ -399,7 +399,7 @@ func TestBruteForceLogic(t *testing.T) {
 			config.GetFile().
 				GetServer().
 				GetRedis().
-				GetPrefix() + ":bf:TR:" + testIPAddress).
+				GetPrefix() + "bf:TR:" + testIPAddress).
 			SetVal(map[string]string{
 				"positive": "100",
 				"negative": "5",

--- a/server/bruteforce/tolerate/tolerate.go
+++ b/server/bruteforce/tolerate/tolerate.go
@@ -520,7 +520,7 @@ func (t *tolerateImpl) getHouseKeeper() *houseKeeper {
 
 // getRedisKey constructs a Redis key using the configured prefix and the given IP address.
 func (t *tolerateImpl) getRedisKey(ipAddress string) string {
-	return config.GetFile().GetServer().GetRedis().GetPrefix() + ":bf:TR:" + ipAddress
+	return config.GetFile().GetServer().GetRedis().GetPrefix() + "bf:TR:" + ipAddress
 }
 
 // logDbgTolerate logs debug information about tolerance evaluation, including interaction counts and thresholds.


### PR DESCRIPTION
…orce package

Simplified Redis key construction by eliminating extra colons in `bruteforce_test.go` and `tolerate.go`. Improves consistency with Redis key naming conventions.