### PR TITLE
Refactor: Remove UPX compression for `nauthilus` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN GIT_TAG=$(git describe --tags --abbrev=0) && echo "tag="${GIT_TAG}"" && \
     cd server && go build -mod=vendor -tags="avx netgo" \
     -trimpath \
     -ldflags="-s -w -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X main.version=${GIT_TAG}-${GIT_COMMIT}" \
-    -o nauthilus . && \
-    upx -1 --lzma nauthilus
+    -o nauthilus
 
 RUN cd docker-healthcheck && go build -mod=vendor -ldflags="-s -w" -o healthcheck . && upx --best --lzma healthcheck
 RUN cd contrib/smtp-server && go build -mod=vendor -ldflags="-s -w" -o fakesmtp . && upx --best --lzma fakesmtp


### PR DESCRIPTION
Dropped UPX compression step for `nauthilus` binary to streamline the build process.