### PR TITLE
Refactor: Reintroduce UPX compression for binaries in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apk add --no-cache build-base git upx
 RUN GIT_TAG=$(git describe --tags --abbrev=0) && echo "tag="${GIT_TAG}"" && \
     GIT_COMMIT=$(git rev-parse --short HEAD) && echo "commit="${GIT_COMMIT}"" && \
     cd server && go build -mod=vendor -tags="avx netgo" \
-    -trimpath \
     -ldflags="-s -w -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X main.version=${GIT_TAG}-${GIT_COMMIT}" \
-    -o nauthilus
+    -o nauthilus . && \
+    upx --best --lzma nauthilus
 
 RUN cd docker-healthcheck && go build -mod=vendor -ldflags="-s -w" -o healthcheck . && upx --best --lzma healthcheck
 RUN cd contrib/smtp-server && go build -mod=vendor -ldflags="-s -w" -o fakesmtp . && upx --best --lzma fakesmtp


### PR DESCRIPTION
Added UPX compression with `--best --lzma` for `nauthilus`, `healthcheck`, and `fakesmtp` binaries to optimize binary size during the build process.