### PR TITLE
Refactor: Update config handling and Dockerfile for enhanced flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache build-base git upx
 RUN GIT_TAG=$(git describe --tags --abbrev=0) && echo "tag="${GIT_TAG}"" && \
     GIT_COMMIT=$(git rev-parse --short HEAD) && echo "commit="${GIT_COMMIT}"" && \
     cd server && go build -mod=vendor -tags="avx netgo" \
+    -trimpath \
     -ldflags="-s -w -X main.buildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X main.version=${GIT_TAG}-${GIT_COMMIT}" \
     -o nauthilus . && \
     upx --best --lzma nauthilus
@@ -56,4 +57,4 @@ EXPOSE 8080
 
 USER nauthilus
 
-CMD ["/usr/app/nauthilus"]
+CMD ["/usr/app/nauthilus", "-config", "/etc/nauthilus/nauthilus.yml", "-config-format", "yaml"]

--- a/server/config/file.go
+++ b/server/config/file.go
@@ -43,6 +43,9 @@ import (
 // LoadableConfig is a variable of type *FileSettings that represents the configuration file that can be loaded.
 var file File
 
+// ConfigFilePath stores the path to the configuration file specified via the -config flag
+var ConfigFilePath string
+
 // GetFile returns the loaded FileSettings configuration instance.
 func GetFile() File {
 	if file == nil {
@@ -2306,12 +2309,14 @@ func bindEnvs(i any, parts ...string) error {
 func NewFile() (newCfg File, err error) {
 	newCfg = &FileSettings{}
 
-	viper.SetConfigName("nauthilus") // name of environment file (without extension)
-	// Note: Config type is now set via command line flag in server.go
-	viper.AddConfigPath(".")
-	viper.AddConfigPath("$HOME/.nauthilus")
-	viper.AddConfigPath("/etc/nauthilus/")
-	viper.AddConfigPath("/usr/local/etc/nauthilus/")
+	if ConfigFilePath == "" {
+		viper.SetConfigName("nauthilus") // name of environment file (without extension)
+		// Note: Config type is now set via command line flag in server.go
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("$HOME/.nauthilus")
+		viper.AddConfigPath("/etc/nauthilus/")
+		viper.AddConfigPath("/usr/local/etc/nauthilus/")
+	}
 
 	err = viper.ReadInConfig()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -58,9 +58,6 @@ import (
 // json is a package-level variable for jsoniter with standard configuration
 var json = jsoniter.ConfigFastest
 
-// configFilePath stores the path to the configuration file specified via the -config flag
-var configFilePath string
-
 // contextTuple represents a tuple that contains a context and a cancel function.
 // This type is used for managing contexts and cancellations in various parts of the application.
 type contextTuple struct {
@@ -108,9 +105,9 @@ func setupConfiguration() (err error) {
 	setTimeZone()
 
 	// If a specific configuration file is provided via the -config flag, check if it exists
-	if configFilePath != "" {
-		if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
-			return fmt.Errorf("specified configuration file does not exist: %s", configFilePath)
+	if config.ConfigFilePath != "" {
+		if _, err := os.Stat(config.ConfigFilePath); os.IsNotExist(err) {
+			return fmt.Errorf("specified configuration file does not exist: %s", config.ConfigFilePath)
 		}
 	}
 
@@ -934,7 +931,7 @@ func parseFlagsAndPrintVersion() {
 	}
 
 	if *configFlag != "" {
-		configFilePath = *configFlag
+		config.ConfigFilePath = *configFlag
 
 		viper.SetConfigFile(*configFlag)
 	}


### PR DESCRIPTION
Replaced `configFilePath` with `ConfigFilePath` in `server/config`. Modified Dockerfile to support custom configuration path and format via command-line arguments. Enhanced build flags with `-trimpath` for optimized binaries.