### PR TITLE
Refactor: Adjust Lua module preload logic for `LuaModNeural`

### DIFF
--- a/server/lualib/feature/feature.go
+++ b/server/lualib/feature/feature.go
@@ -173,6 +173,9 @@ func (r *Request) registerModule(L *lua.LState, ctx *gin.Context, modName string
 		} else {
 			L.RaiseError("LDAP backend not activated")
 		}
+	case definitions.LuaModNeural:
+		// XXX: It will only have an effect in nauthilus_call_neural_network!
+		L.PreloadModule(definitions.LuaModNeural, lualib.LoaderModNeural(ctx))
 	default:
 		return
 	}
@@ -407,7 +410,6 @@ func (r *Request) CollectAdditionalFeatures(ctx *gin.Context) error {
 
 	// Register the dynamic loader
 	r.registerDynamicLoader(L, ctx)
-	L.PreloadModule(definitions.LuaModNeural, lualib.LoaderModNeural(ctx))
 
 	// Set up globals
 	globals := L.NewTable()


### PR DESCRIPTION
Moved `LuaModNeural` preload call to a context-specific case block, ensuring functionality is limited to `nauthilus_call_neural_network`. Removed redundant preload from dynamic loader registration for better clarity and modularity.