### PR TITLE
Fix: Return `nil` to indicate HTTP response is already handled in `he…

### DIFF
--- a/server/lua-plugins.d/hooks/hello-world-request-dump.lua
+++ b/server/lua-plugins.d/hooks/hello-world-request-dump.lua
@@ -141,5 +141,6 @@ function nauthilus_run_hook(logging, session)
         nauthilus_util.print_result(logging, result)
     end
 
-    return result
+    -- Returning nil tells the framework that we already handled the HTTP response
+    return nil
 end


### PR DESCRIPTION
…llo-world-request-dump`